### PR TITLE
fix: Remove the need to import react-chatbotify.css file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "typescript": "^5.1.6",
         "vite": "^4.5.2",
         "vite-plugin-dts": "^3.4.0",
+        "vite-plugin-libcss": "^1.1.1",
         "vite-plugin-svgr": "^3.2.0"
       }
     },
@@ -5401,6 +5402,42 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-libcss": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-libcss/-/vite-plugin-libcss-1.1.1.tgz",
+      "integrity": "sha512-WAk6U9iYWMbcu7cdw4wACpVebZiLHMyyE9KTcBzzkTt1cnXj3a7loIoIGNblx+xMb9quPpO3iRbNTOnIFDzgmg==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^9.0.1"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite-plugin-libcss/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vite-plugin-libcss/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vite-plugin-svgr": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./dist/react-chatbotify.css": {
-      "import": "./dist/react-chatbotify.css",
-      "require": "./dist/react-chatbotify.css"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./dist/react-chatbotify.css": {
+      "import": "./dist/react-chatbotify.css",
+      "require": "./dist/react-chatbotify.css"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript": "^5.1.6",
     "vite": "^4.5.2",
     "vite-plugin-dts": "^3.4.0",
+    "vite-plugin-libcss": "^1.1.1",
     "vite-plugin-svgr": "^3.2.0"
   },
   "browserslist": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
-import dts from 'vite-plugin-dts';
+import dts from "vite-plugin-dts";
 import path from "path";
+import libCss from "vite-plugin-libcss";
 
 import { defineConfig } from "vite";
 
@@ -12,36 +13,38 @@ export default defineConfig({
       entry: path.resolve(__dirname, "src/index.tsx"),
       name: "react-chatbotify",
       fileName: "index",
-      formats: ["es", "cjs"]
+      formats: ["es", "cjs"],
     },
     rollupOptions: {
       external: ["react", "react-dom"],
       output: {
         globals: {
-          react: "React"
+          react: "React",
         },
         assetFileNames: (assetInfo) => {
-            if (assetInfo.name === "style.css") return "react-chatbotify.css";
-            return assetInfo.name;
+          if (assetInfo.name === "style.css") return "react-chatbotify.css";
+          return assetInfo.name;
         },
-      }
+      },
     },
     outDir: "../dist",
   },
   assetsInclude: ["**/*.svg", "**/*.png", "**/*.wav"],
   plugins: [
     svgr({
-        svgrOptions: {
-            ref: true,
-        },
+      svgrOptions: {
+        ref: true,
+      },
     }),
     react({
       include: "**/*.{jsx,tsx}",
     }),
-    dts()
+    dts(),
+    libCss(),
   ],
   server: {
     port: 3000,
-    host: true
-  }
+    host: true,
+  },
 });
+


### PR DESCRIPTION
#### Description

Fixes the necessity of iimporting css.

No issue to close

#### What change does this PR introduce?

Please select the relevant option(s).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### What is the proposed approach?

is only necessary to add a new vite plugin to add the css as an import

#### Checklist:

- [ ] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)