### PR TITLE
feat: allow custom buttons to be rendered in footer

### DIFF
--- a/src/components/ChatBotFooter/ChatBotFooter.tsx
+++ b/src/components/ChatBotFooter/ChatBotFooter.tsx
@@ -46,18 +46,34 @@ const ChatBotFooter = ({
 	// handles options for bot
 	const { botOptions } = useBotOptions();
 
+	const renderFileAttachment = () => {
+		return (
+			<FileAttachmentButton inputRef={inputRef}
+				flow={flow} getCurrPath={getCurrPath} openChat={openChat}
+				getPrevPath={getPrevPath} handleActionInput={handleActionInput} injectMessage={injectMessage}
+				streamMessage={streamMessage}
+			/>
+		)
+	}
+
+	const renderEmojiPicker = () => {
+		return (<EmojiPicker inputRef={inputRef} textAreaDisabled={textAreaDisabled}/>)
+	}
+	
 	return (
 		<div style={botOptions.footerStyle} className="rcb-chat-footer-container">
 			<div className="rcb-chat-footer">
-				{!botOptions.fileAttachment?.disabled &&
-					<FileAttachmentButton inputRef={inputRef} flow={flow} getCurrPath={getCurrPath} openChat={openChat}
-						getPrevPath={getPrevPath} handleActionInput={handleActionInput} injectMessage={injectMessage}
-						streamMessage={streamMessage}
-					/>
-				}
-				{!botOptions.emoji?.disabled &&
-					<EmojiPicker inputRef={inputRef} textAreaDisabled={textAreaDisabled}/>
-				}
+				{botOptions.footer?.buttons?.map((element) => {
+					if(element === "file-attachment" && !botOptions.fileAttachment?.disabled){
+						return renderFileAttachment()
+					}
+					else if (element === "emoji-picker" && !botOptions.emoji?.disabled){
+						return renderEmojiPicker()
+					}
+					else if(element !== "file-attachment" && element !== "emoji-picker"){
+						return element
+					}
+				})}
 			</div>
 			<span>{botOptions.footer?.text}</span>
 		</div>

--- a/src/components/ChatBotFooter/ChatBotFooter.tsx
+++ b/src/components/ChatBotFooter/ChatBotFooter.tsx
@@ -1,5 +1,5 @@
 
-import React,{ RefObject } from "react";
+import React, { RefObject } from "react";
 
 import EmojiPicker from "./EmojiPicker/EmojiPicker";
 import FileAttachmentButton from "./FileAttachmentButton/FileAttachmentButton";
@@ -64,16 +64,13 @@ const ChatBotFooter = ({
 		<div style={botOptions.footerStyle} className="rcb-chat-footer-container">
 			<div className="rcb-chat-footer">
 				{botOptions.footer?.buttons?.map((element) => {
-					if (element === "file-attachment" && !botOptions.fileAttachment?.disabled){
-						return renderFileAttachment()
-					}
-					else if (element === "emoji-picker" && !botOptions.emoji?.disabled){
-						return renderEmojiPicker()
-					}
-					else if (element !== "file-attachment" && element !== "emoji-picker" 
-								&& React.isValidElement(element)){
-						return element
-					
+					if (element === "file-attachment" && !botOptions.fileAttachment?.disabled) {
+						return renderFileAttachment();
+					} else if (element === "emoji-picker" && !botOptions.emoji?.disabled) {
+						return renderEmojiPicker();
+					} else if (element !== "file-attachment" && element !== "emoji-picker" 
+						&& React.isValidElement(element)) {
+						return element;
 					}
 				})}
 			</div>

--- a/src/components/ChatBotFooter/ChatBotFooter.tsx
+++ b/src/components/ChatBotFooter/ChatBotFooter.tsx
@@ -1,5 +1,5 @@
 
-import { RefObject } from "react";
+import React,{ RefObject } from "react";
 
 import EmojiPicker from "./EmojiPicker/EmojiPicker";
 import FileAttachmentButton from "./FileAttachmentButton/FileAttachmentButton";
@@ -59,19 +59,21 @@ const ChatBotFooter = ({
 	const renderEmojiPicker = () => {
 		return (<EmojiPicker inputRef={inputRef} textAreaDisabled={textAreaDisabled}/>)
 	}
-	
+
 	return (
 		<div style={botOptions.footerStyle} className="rcb-chat-footer-container">
 			<div className="rcb-chat-footer">
 				{botOptions.footer?.buttons?.map((element) => {
-					if(element === "file-attachment" && !botOptions.fileAttachment?.disabled){
+					if (element === "file-attachment" && !botOptions.fileAttachment?.disabled){
 						return renderFileAttachment()
 					}
 					else if (element === "emoji-picker" && !botOptions.emoji?.disabled){
 						return renderEmojiPicker()
 					}
-					else if(element !== "file-attachment" && element !== "emoji-picker"){
+					else if (element !== "file-attachment" && element !== "emoji-picker" 
+								&& React.isValidElement(element)){
 						return element
+					
 					}
 				})}
 			</div>

--- a/src/services/BotOptionsService.tsx
+++ b/src/services/BotOptionsService.tsx
@@ -129,6 +129,7 @@ const defaultOptions = {
 				</span>
 			</div>
 		),
+		buttons:["file-attachment","emoji-picker"]
 	},
 	fileAttachment: {
 		disabled: false,

--- a/src/services/BotOptionsService.tsx
+++ b/src/services/BotOptionsService.tsx
@@ -129,7 +129,7 @@ const defaultOptions = {
 				</span>
 			</div>
 		),
-		buttons:["file-attachment","emoji-picker"]
+		buttons: ["file-attachment","emoji-picker"]
 	},
 	fileAttachment: {
 		disabled: false,

--- a/src/types/Options.tsx
+++ b/src/types/Options.tsx
@@ -98,6 +98,7 @@ export type Options = {
 	},
 	footer?: {
 		text?: string | JSX.Element;
+		buttons?: Array<JSX.Element | string>;
 	},
 	fileAttachment?: {
 		disabled?: boolean;


### PR DESCRIPTION
#### Description

A new option called `buttons` is added to the footer options. It renders File Attachment and Emoji Picker by default. Custom buttons can be added in any order to footer by passing the components as an array to the `buttons` prop.
Closes #31 
<img width="395" alt="Screenshot 2024-04-15 at 12 23 06 AM" src="https://github.com/tjtanjin/react-chatbotify/assets/24211855/7ee855be-2b92-4fac-9e4b-b776ccdda652">
<img width="391" alt="Screenshot 2024-04-15 at 12 22 51 AM" src="https://github.com/tjtanjin/react-chatbotify/assets/24211855/dea80ee0-8537-423d-929e-e8495a37d2eb">
<img width="391" alt="Screenshot 2024-04-15 at 12 22 30 AM" src="https://github.com/tjtanjin/react-chatbotify/assets/24211855/f3be7b77-1254-4872-bda0-8f7292a82834">

Please select the relevant option(s).

#### What change does this PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)