### PR TITLE
feat: allow custom buttons to be rendered in header

### DIFF
--- a/src/components/ChatBotHeader/ChatBotHeader.tsx
+++ b/src/components/ChatBotHeader/ChatBotHeader.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from "react";
+import React, { MouseEvent } from "react";
 
 import { useBotOptions } from "../../context/BotOptionsContext";
 
@@ -57,6 +57,42 @@ const ChatBotHeader = ({
 		setBotOptions({...botOptions, isOpen: false});
 	}
 
+	/**
+	 * Renders notification button.
+	 */
+
+	const renderNotificationButton = () => {
+		return (
+			<div
+				style={headerImages.notificationIcon}
+				onMouseDown={(event: MouseEvent) => {
+					event.preventDefault();
+					handleToggleNotification();
+				}}
+				className={`rcb-notification-icon-${
+					notificationToggledOn ? "on" : "off"
+				}`}
+			></div>
+		);
+	};
+
+	/**
+	 * Renders audio button.
+	 */
+
+	const renderAudioButton = () => {
+		return (
+			<div
+				style={headerImages.audioIcon}
+				onMouseDown={(event: MouseEvent) => {
+					event.preventDefault();
+					handleToggleAudio();
+				}}
+				className={`rcb-audio-icon-${audioToggledOn ? "on" : "off"}`}
+			></div>
+		);
+	};
+
 	return (
 		<div style={headerStyle} className="rcb-chat-header-container">
 			<div className="rcb-chat-header">
@@ -66,28 +102,20 @@ const ChatBotHeader = ({
 				{botOptions.header?.title}
 			</div>
 			<div className="rcb-chat-header">
-				{!botOptions.notification?.disabled && !botOptions.theme?.embedded &&
-					<div
-						style={headerImages.notificationIcon}
-						onMouseDown={(event: MouseEvent) => {
-							event.preventDefault();
-							handleToggleNotification();
-						}}
-						className={`rcb-notification-icon-${notificationToggledOn ? "on" : "off"}`}
-					>
-					</div>
-				}
-				{!botOptions.audio?.disabled &&
-					<div
-						style={headerImages.audioIcon}
-						onMouseDown={(event: MouseEvent) => {
-							event.preventDefault();
-							handleToggleAudio();
-						}}
-						className={`rcb-audio-icon-${audioToggledOn ? "on" : "off"}`}
-					>
-					</div>
-				}
+				{botOptions.header?.buttons?.map((button, index) => {
+					if (
+						button === "notification-button" &&
+						!botOptions.notification?.disabled &&
+						!botOptions.theme?.embedded
+					) {
+						return <React.Fragment key={index}>{renderNotificationButton()}</React.Fragment>;
+					} else if (button === "audio-button" && !botOptions.audio?.disabled) {
+						return <React.Fragment key={index}>{renderAudioButton()}</React.Fragment>;
+					} else if (React.isValidElement(button)) {
+						return <React.Fragment key={index}>{button}</React.Fragment>;
+					}
+									
+				})}
 				{!botOptions.theme?.embedded &&
 					<div
 						style={headerImages.closeChatIcon}

--- a/src/services/BotOptionsService.tsx
+++ b/src/services/BotOptionsService.tsx
@@ -50,6 +50,7 @@ const defaultOptions = {
 		),
 		showAvatar: true,
 		avatar: botAvatar,
+		buttons: ["audio-button", "notification-button"],
 		closeChatIcon: closeChatIcon,
 	},
 	notification: {

--- a/src/types/Options.tsx
+++ b/src/types/Options.tsx
@@ -29,6 +29,7 @@ export type Options = {
 		title?: string | JSX.Element;
 		showAvatar?: boolean;
 		avatar?: string;
+		buttons?: Array<JSX.Element | string>;
 		closeChatIcon?: string;
 	},
 	notification?: {


### PR DESCRIPTION
#### Description

Similar to the work done by @mushroomgenie on the footer component PR #33, this pull request introduces a new option called buttons to the header options. By default, the header now renders Notification, Audio, and Close buttons. Users can now customize the header buttons by passing their own components as an array to the buttons prop.

![Screenshot 2024-04-16 152343](https://github.com/tjtanjin/react-chatbotify/assets/88333731/1eb15b33-c9e8-4eb8-98f2-94facb0c0c0b)
![Screenshot 2024-04-16 152616](https://github.com/tjtanjin/react-chatbotify/assets/88333731/662596a8-47dd-4540-9663-080f7d287597)
![Screenshot 2024-04-16 152519](https://github.com/tjtanjin/react-chatbotify/assets/88333731/3acb44cb-648e-4ae2-adf3-f10d72ce779e)


Closes #30 

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)