### PR TITLE
feat: ChatInput component support custom buttons

### DIFF
--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -1,5 +1,4 @@
-
-import { useState, ChangeEvent, FormEvent, KeyboardEvent, RefObject, useEffect, MouseEvent } from "react";
+import React, { useState, ChangeEvent, FormEvent, KeyboardEvent, RefObject, useEffect, MouseEvent } from "react";
 
 import SendButton from "./SendButton/SendButton";
 import VoiceButton from "./VoiceButton/VoiceButton";
@@ -7,7 +6,6 @@ import { isDesktop } from "../../services/Utils";
 import { useBotOptions } from "../../context/BotOptionsContext";
 
 import "./ChatBotInput.css";
-import React from "react";
 
 /**
  * Contains chat input field for user to enter messages.
@@ -189,17 +187,17 @@ const ChatBotInput = ({
 			/>
 			<div className="rcb-chat-input-button-container">
 				{botOptions.chatInput?.buttons?.map((button, index) => {
-					switch(button){
-					case "send":
+					if(button === "send"){
 						return <SendButton key={index} handleSubmit={handleSubmit}/>
-					case "voice":
+					}else if(button === "voice"){
 						return !botOptions.voice?.disabled && isDesktop &&
 							<VoiceButton key={index} inputRef={inputRef} textAreaDisabled={textAreaDisabled}
 								voiceToggledOn={voiceToggledOn} handleToggleVoice={handleToggleVoice}
 								triggerSendVoiceInput={triggerSendVoiceInput} setInputLength={setInputLength}
 							/>
+					}else {
+						return <React.Fragment key={index}>{button}</React.Fragment>
 					}
-					return <React.Fragment key={index}>{button}</React.Fragment>
 				})}
 				{botOptions.chatInput?.showCharacterCount
 					&& botOptions.chatInput?.characterLimit != null

--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -165,6 +165,25 @@ const ChatBotInput = ({
 		setVoiceInputTrigger(prev => !prev);
 	}
 
+	/**
+	 * Renders voice button
+	 */
+	const renderVoiceButton = () => {
+		return (
+			<VoiceButton inputRef={inputRef} textAreaDisabled={textAreaDisabled}
+				voiceToggledOn={voiceToggledOn} handleToggleVoice={handleToggleVoice}
+				triggerSendVoiceInput={triggerSendVoiceInput} setInputLength={setInputLength}
+			/>
+		)
+	}
+
+	/**
+	 * Renders send button
+	 */
+	const renderSendButton = () => {
+		return (<SendButton handleSubmit={handleSubmit}/>)
+	}
+
 	return (
 		<div 
 			onMouseDown={(event: MouseEvent) => {
@@ -187,15 +206,11 @@ const ChatBotInput = ({
 			/>
 			<div className="rcb-chat-input-button-container">
 				{botOptions.chatInput?.buttons?.map((button, index) => {
-					if(button === "send"){
-						return <SendButton key={index} handleSubmit={handleSubmit}/>
-					}else if(button === "voice"){
-						return !botOptions.voice?.disabled && isDesktop &&
-							<VoiceButton key={index} inputRef={inputRef} textAreaDisabled={textAreaDisabled}
-								voiceToggledOn={voiceToggledOn} handleToggleVoice={handleToggleVoice}
-								triggerSendVoiceInput={triggerSendVoiceInput} setInputLength={setInputLength}
-							/>
-					}else {
+					if (button === "send"){
+						return <React.Fragment key={index}>{renderSendButton()}</React.Fragment>
+					}else if (button === "voice" && !botOptions.voice?.disabled && isDesktop){
+						return <React.Fragment key={index}>{renderVoiceButton()}</React.Fragment>
+					}else if (React.isValidElement(button)) {
 						return <React.Fragment key={index}>{button}</React.Fragment>
 					}
 				})}

--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -206,11 +206,11 @@ const ChatBotInput = ({
 			/>
 			<div className="rcb-chat-input-button-container">
 				{botOptions.chatInput?.buttons?.map((button, index) => {
-					if (button === "send"){
+					if (button === "send") {
 						return <React.Fragment key={index}>{renderSendButton()}</React.Fragment>
-					}else if (button === "voice" && !botOptions.voice?.disabled && isDesktop){
+					} else if (button === "voice" && !botOptions.voice?.disabled && isDesktop) {
 						return <React.Fragment key={index}>{renderVoiceButton()}</React.Fragment>
-					}else if (React.isValidElement(button)) {
+					} else if (React.isValidElement(button)) {
 						return <React.Fragment key={index}>{button}</React.Fragment>
 					}
 				})}

--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -7,6 +7,7 @@ import { isDesktop } from "../../services/Utils";
 import { useBotOptions } from "../../context/BotOptionsContext";
 
 import "./ChatBotInput.css";
+import React from "react";
 
 /**
  * Contains chat input field for user to enter messages.
@@ -187,13 +188,19 @@ const ChatBotInput = ({
 				onBlur={handleBlur}
 			/>
 			<div className="rcb-chat-input-button-container">
-				{!botOptions.voice?.disabled && isDesktop &&
-					<VoiceButton inputRef={inputRef} textAreaDisabled={textAreaDisabled}
-						voiceToggledOn={voiceToggledOn} handleToggleVoice={handleToggleVoice}
-						triggerSendVoiceInput={triggerSendVoiceInput} setInputLength={setInputLength}
-					/>
-				}
-				<SendButton handleSubmit={handleSubmit}/>
+				{botOptions.chatInput?.buttons?.map((button, index) => {
+					switch(button){
+					case "send":
+						return <SendButton key={index} handleSubmit={handleSubmit}/>
+					case "voice":
+						return !botOptions.voice?.disabled && isDesktop &&
+							<VoiceButton key={index} inputRef={inputRef} textAreaDisabled={textAreaDisabled}
+								voiceToggledOn={voiceToggledOn} handleToggleVoice={handleToggleVoice}
+								triggerSendVoiceInput={triggerSendVoiceInput} setInputLength={setInputLength}
+							/>
+					}
+					return <React.Fragment key={index}>{button}</React.Fragment>
+				})}
 				{botOptions.chatInput?.showCharacterCount
 					&& botOptions.chatInput?.characterLimit != null
 					&& botOptions.chatInput?.characterLimit > 0

--- a/src/services/BotOptionsService.tsx
+++ b/src/services/BotOptionsService.tsx
@@ -88,6 +88,7 @@ const defaultOptions = {
 		sendOptionOutput: true,
 		sendCheckboxOutput: true,
 		sendAttachmentOutput: true,
+		buttons: ["voice", "send"]
 	},
 	chatWindow: {
 		showScrollbar: false,
@@ -282,7 +283,7 @@ const getCombinedOptions = (preferredOptions: Options, baseOptions: Options): Op
 				continue;
 			}
 
-			if (typeof source[key] === 'object' && source[key] !== null) {
+			if (typeof source[key] === 'object' && source[key] !== null && key !== 'buttons') {
 				if (!target[key]) {
 					target[key] = Array.isArray(source[key]) ? [] : {};
 				}

--- a/src/types/Options.tsx
+++ b/src/types/Options.tsx
@@ -67,6 +67,7 @@ export type Options = {
 		sendOptionOutput?: boolean;
 		sendCheckboxOutput?: boolean;
 		sendAttachmentOutput?: boolean;
+		buttons?: Array<JSX.Element | string>;
 	},
 	chatWindow?: {
 		showScrollbar?: boolean;


### PR DESCRIPTION
#### Description

buttons is added to chatInput options to allow custom buttons. Can rearrange button position through array position. By default it will render voice and send button. 
![image](https://github.com/tjtanjin/react-chatbotify/assets/106626619/940d4792-8442-49b8-a15c-508e6a1898c5)


Closes #35 

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)