### PR TITLE
truncate load history button text

### DIFF
--- a/src/components/ChatHistoryButton/ChatHistoryButton.css
+++ b/src/components/ChatHistoryButton/ChatHistoryButton.css
@@ -1,29 +1,37 @@
 /* Chat History Container */
 
 .rcb-view-history-container {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	padding-top: 10px;
-	padding-bottom: 5px;
-	min-height: 35px;
-	max-height: 45px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 10px;
+  padding-bottom: 5px;
+  min-height: 35px;
+  max-height: 45px;
 }
 
 /* View Chat History Button */
 
 .rcb-view-history-button {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 6px 12px;
-	border-radius: 20px;
-	color: #adadad;
-	font-size: 12px;
-	background-color: #fff;
-	border-color: #adadad;
-	border-width: 0.5px;
-	border-style: solid;
-	cursor: pointer;
-	transition: color 0.3s ease, border-color 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 20px;
+  color: #adadad;
+  font-size: 12px;
+  background-color: #fff;
+  border-color: #adadad;
+  border-width: 0.5px;
+  border-style: solid;
+  cursor: pointer;
+  transition: color 0.3s ease, border-color 0.3s ease;
+  max-width: 50%;  
+}
+
+.rcb-view-history-button > p{
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/components/ChatHistoryButton/ChatHistoryButton.tsx
+++ b/src/components/ChatHistoryButton/ChatHistoryButton.tsx
@@ -6,18 +6,17 @@ import "./ChatHistoryButton.css";
 
 /**
  * Supports viewing of old messages.
- * 
+ *
  * @param chatHistory string representation of old chat messages
  * @param showChatHistory entry point for showing of chat history
  */
 const ChatHistoryButton = ({
 	chatHistory,
-	showChatHistory
+	showChatHistory,
 }: {
-	chatHistory: string;
-	showChatHistory: (chatHistory: string) => void;
+    chatHistory: string;
+    showChatHistory: (chatHistory: string) => void;
 }) => {
-
 	// handles options for bot
 	const { botOptions } = useBotOptions();
 
@@ -28,36 +27,42 @@ const ChatHistoryButton = ({
 	const chatHistoryButtonHoveredStyle: React.CSSProperties = {
 		color: botOptions.theme?.primaryColor,
 		borderColor: botOptions.theme?.primaryColor,
-		...botOptions.chatHistoryButtonHoveredStyle
+		...botOptions.chatHistoryButtonHoveredStyle,
 	};
 
 	/**
-	 * Handles mouse enter event on view chat history button.
-	 */
+     * Handles mouse enter event on view chat history button.
+     */
 	const handleMouseEnter = () => {
 		setIsHovered(true);
 	};
 
 	/**
-	 * Handles mouse leave event on view chat history button.
-	 */
+     * Handles mouse leave event on view chat history button.
+     */
 	const handleMouseLeave = () => {
 		setIsHovered(false);
 	};
-	
+
 	return (
 		<div className="rcb-view-history-container">
 			<div
 				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave} 
-				style={isHovered ? chatHistoryButtonHoveredStyle : botOptions.chatHistoryButtonStyle}
+				onMouseLeave={handleMouseLeave}
+				style={
+					isHovered
+						? chatHistoryButtonHoveredStyle
+						: botOptions.chatHistoryButtonStyle
+				}
 				onMouseDown={(event: MouseEvent) => {
 					event.preventDefault();
 					showChatHistory(chatHistory);
 				}}
 				className="rcb-view-history-button"
 			>
-				{botOptions.chatHistory?.viewChatHistoryButtonText}
+				<p>
+					{botOptions.chatHistory?.viewChatHistoryButtonText}
+				</p>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
#### Description

Regarding your issue  #46 ( [Bug] Fix load & previous chat history text overflow )
Long text's were overflowing the button which makes the UI look bad.

Closes #46 

#### What change does this PR introduce?

The PR includes changes in the files 
1. ChatHistoryButton.tsx
2. ChatHistoryButton.css

Please select the relevant option(s).

- [ ✔️] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

The approach I end up with is by not allowing the text to wrap and by making the text overflow to ellipses.

#### Checklist:

- [✔️ ] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [✔️ ] Testing has been done for the change(s) added (for bug fixes/features)
- [ ✔️
<img width="239" alt="Screenshot 2024-04-30 133130" src="https://github.com/tjtanjin/react-chatbotify/assets/149044653/09b5e0c4-f2f7-418f-853c-a8f1ee2aec4f">
] Relevant comments/docs have been added/updated (for bug fixes/features)