### PR TITLE
fix: set speech recognition type and use the right object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
+        "@types/dom-speech-recognition": "^0.0.4",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "@typescript-eslint/eslint-plugin": "^5.60.1",
@@ -927,6 +928,12 @@
       "version": "1.0.38",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.4.tgz",
+      "integrity": "sha512-zf2GwV/G6TdaLwpLDcGTIkHnXf8JEf/viMux+khqKQKDa8/8BAUtXXZS563GnvJ4Fg0PBLGAaFf2GekEVSZ6GQ==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.56.10",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "url": "https://github.com/tjtanjin/react-chatbotify"
   },
   "devDependencies": {
+    "@types/dom-speech-recognition": "^0.0.4",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "@typescript-eslint/eslint-plugin": "^5.60.1",

--- a/src/services/VoiceService.tsx
+++ b/src/services/VoiceService.tsx
@@ -2,8 +2,7 @@ import { RefObject, Dispatch, SetStateAction } from "react";
 
 import { Options } from "../types/Options";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SpeechRecognition = (window as any).speechRecognition || (window as any).webkitSpeechRecognition;
+const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 const recognition = SpeechRecognition != null ? new SpeechRecognition() : null;
 let inactivityTimer: ReturnType<typeof setTimeout> | null;
 let autoSendTimer: ReturnType<typeof setTimeout>;
@@ -34,8 +33,7 @@ export const startVoiceRecording = (botOptions: Options, handleToggleVoice: () =
 	const inactivityPeriod = botOptions.voice?.timeoutPeriod;
 	const autoSendPeriod = botOptions.voice?.autoSendPeriod;
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	recognition.onresult = (event: any) => {
+	recognition.onresult = event => {
 		clearTimeout(inactivityTimer as ReturnType<typeof setTimeout>);
 		inactivityTimer = null;
 		clearTimeout(autoSendTimer);


### PR DESCRIPTION
#### Description

This replaces any type by its actual type. As well, it uses the right object, `window.SpeechRecognition` instead of `window.speechRecognition`.

[Docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API)

Closes #(issue)

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)