### PR TITLE
Cache themes and retrieve from cache when available

### DIFF
--- a/src/services/ThemeService.tsx
+++ b/src/services/ThemeService.tsx
@@ -4,11 +4,12 @@ import { Theme } from "../types/Theme";
 
 const DEFAULT_URL = import.meta.env.VITE_THEME_BASE_CDN_URL;
 
-const CACHE_KEY = 'rcb-theme';
+const CACHE_KEY_PREFIX = 'rcb-theme';
 const EXPIRY_DAYS = 30;
 
-const getCachedTheme = (id: string, version: string) => {
-	const cachedTheme = localStorage.getItem(`${CACHE_KEY}_${version}_${id}`);
+const getCachedTheme = (id: string, version: string | undefined) => {
+	const cachedTheme = version ? localStorage.getItem(`${CACHE_KEY_PREFIX}_${version}_${id}`) 
+		: localStorage.getItem(`${CACHE_KEY_PREFIX}_${id}`);
 	if (!cachedTheme) return null;
 
 	const themeData = JSON.parse(cachedTheme);
@@ -16,7 +17,7 @@ const getCachedTheme = (id: string, version: string) => {
 	const expiryDate = new Date(themeData.expiry);
 
 	if (now > expiryDate) {
-		localStorage.removeItem(CACHE_KEY);
+		localStorage.removeItem(CACHE_KEY_PREFIX);
 		return null;
 	}
 
@@ -35,7 +36,7 @@ const setCachedTheme = (id: string, version: string | undefined, settings: Setti
 		expiryDate
 	};
 
-	localStorage.setItem(`${CACHE_KEY}_${id}_${version}`, JSON.stringify(themeCacheData));
+	localStorage.setItem(`${CACHE_KEY_PREFIX}_${id}_${version}`, JSON.stringify(themeCacheData));
 }
 
 /**
@@ -112,7 +113,7 @@ export const processAndFetchThemeConfig = async (theme: Theme): Promise<{setting
 		console.error(`Failed to fetch styles.json from ${inlineStylesUrl}`);
 	}
 
-	setCachedTheme(`${CACHE_KEY}_${id}_${version}`, themeVersion, settings, inlineStyles);
+	setCachedTheme(`${CACHE_KEY_PREFIX}_${id}_${version}`, themeVersion, settings, inlineStyles);
 
 	return {settings, styles: inlineStyles}
 }

--- a/src/services/ThemeService.tsx
+++ b/src/services/ThemeService.tsx
@@ -4,11 +4,11 @@ import { Theme } from "../types/Theme";
 
 const DEFAULT_URL = import.meta.env.VITE_THEME_BASE_CDN_URL;
 
-const CACHE_KEY = 'chatify-bot-theme-cache';
+const CACHE_KEY = 'rcb-theme';
 const EXPIRY_DAYS = 30;
 
-const getCachedTheme = () => {
-	const cachedTheme = localStorage.getItem(CACHE_KEY);
+const getCachedTheme = (id: string, version: string) => {
+	const cachedTheme = localStorage.getItem(`${CACHE_KEY}_${version}_${id}`);
 	if (!cachedTheme) return null;
 
 	const themeData = JSON.parse(cachedTheme);
@@ -35,7 +35,7 @@ const setCachedTheme = (id: string, version: string | undefined, settings: Setti
 		expiryDate
 	};
 
-	localStorage.setItem(CACHE_KEY, JSON.stringify(themeCacheData));
+	localStorage.setItem(`${CACHE_KEY}_${id}_${version}`, JSON.stringify(themeCacheData));
 }
 
 /**
@@ -46,7 +46,8 @@ const setCachedTheme = (id: string, version: string | undefined, settings: Setti
 export const processAndFetchThemeConfig = async (theme: Theme): Promise<{settings: Settings, styles: Styles}> => {
 	const { id, version, base_url = DEFAULT_URL } = theme;
 
-	const cache = getCachedTheme();
+	// try to get the theme from cache
+	const cache = getCachedTheme(id, version);
 
 	if (cache && cache.id === id && cache.version === version) {
 		return { settings: cache.settings, styles: cache }
@@ -111,7 +112,7 @@ export const processAndFetchThemeConfig = async (theme: Theme): Promise<{setting
 		console.error(`Failed to fetch styles.json from ${inlineStylesUrl}`);
 	}
 
-	setCachedTheme(id, themeVersion, settings, inlineStyles);
+	setCachedTheme(`${CACHE_KEY}_${id}_${version}`, themeVersion, settings, inlineStyles);
 
 	return {settings, styles: inlineStyles}
 }

--- a/src/services/ThemeService.tsx
+++ b/src/services/ThemeService.tsx
@@ -36,7 +36,8 @@ const setCachedTheme = (id: string, version: string | undefined, settings: Setti
 		expiryDate
 	};
 
-	localStorage.setItem(`${CACHE_KEY_PREFIX}_${id}_${version}`, JSON.stringify(themeCacheData));
+	version ? localStorage.setItem(`${CACHE_KEY_PREFIX}_${id}_${version}`, JSON.stringify(themeCacheData))
+		: localStorage.setItem(`${CACHE_KEY_PREFIX}_${id}`);
 }
 
 /**

--- a/test/RunTests.js
+++ b/test/RunTests.js
@@ -54,6 +54,7 @@ const run = async() => {
     await executeTest(charLimit);
     await executeTest(newMessagePrompt);
     await executeTest(scrollToBottom);
+    await executeTest(testCacheStorage);
     showTestSummary();
     await driver.quit();
 };
@@ -420,6 +421,21 @@ const scrollToBottom = async () => {
     
     if (!isScrolledToBottom) {
       throw new Error("Chat did not auto-scroll to the bottom when the new message prompt was clicked.");
+    }
+};
+
+const testCacheStorage = async () => {
+    // Simulate selecting a new theme and verify it's cached properly
+    const newTheme = { id: "new-theme", version: "1.0.0", base_url: "http://example.com" };
+
+    await driver.executeScript(`window.localStorage.setItem("theme", ${JSON.stringify(newTheme)})`);
+
+    // Retrieve and verify cached theme
+    const cachedTheme = await driver.executeScript('return window.localStorage.getItem("theme")');
+    const parsedTheme = JSON.parse(cachedTheme);
+
+    if (parsedTheme.id !== newTheme.id || parsedTheme.version !== newTheme.version) {
+        throw new Error("The theme was not cached correctly.");
     }
 };
 


### PR DESCRIPTION
#### Description

This pull request caches the theme data with an expiry date of 30 days to local storage. If a theme exists it is returned and no call to the CDN to get the theme are made

Closes #85 

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

To resolve this issue I simply added cache setting/getting functions in order to check for a cached theme before going to the CDN. If there is no cached theme or it is expired, a call to the CDN is made and the result is then cached for future use. I chose 30 days as an arbitrary number but we can expand or reduce that as needed

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)