### PR TITLE
Fix Icon Cropping Issue in Chat Button

### DIFF
--- a/src/components/ChatBotButton/ChatBotButton.css
+++ b/src/components/ChatBotButton/ChatBotButton.css
@@ -39,6 +39,7 @@
 	background-size: cover;
 	background-repeat: no-repeat;
 	margin: auto;
+	border-radius: inherit;
 }
 
 @keyframes expand {


### PR DESCRIPTION
#### Description

Added border-radius: inherit to allow custom icons to be cropped properly within the chat button’s box.

#### What change does this PR introduce?

This update improves the appearance of the chat button icon by ensuring it does not overlap the previous layout.

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Added border-radius: inherit to the toggle icon’s CSS.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)