### PR TITLE
chore: add inline style for typing indicator

### DIFF
--- a/src/components/ChatBotBody/ChatBotBody.tsx
+++ b/src/components/ChatBotBody/ChatBotBody.tsx
@@ -62,13 +62,13 @@ const ChatBotBody = ({
 	};
 
 	// styles for typing indicator
-	const rcbDot: CSSProperties = {
-		width: "8px",
-		height: "8px",
-		borderRadius: "50%",
-		backgroundColor: "#ccc",
-		marginRight: "4px",
-		animation: "rcb-typing 1s infinite"
+	const rcbTypingIndicatorStyle: CSSProperties = {
+		...styles?.rcbTypingIndicatorStyle
+	};
+
+	// styles for rcb dot
+	const rcbDotStyle: CSSProperties = {
+		...styles?.rcbDotStyle
 	};
 
 	// styles for user bubble
@@ -282,10 +282,10 @@ const ChatBotBody = ({
 						}}
 						className={`rcb-bot-message ${botBubbleEntryStyle}`}
 					>
-						<div className="rcb-typing-indicator">
-							<span style={rcbDot} className="rcb-dot"/>
-							<span style={rcbDot} className="rcb-dot"/>
-							<span style={rcbDot} className="rcb-dot"/>
+						<div className="rcb-typing-indicator" style={rcbTypingIndicatorStyle}>
+							<span className="rcb-dot" style={rcbDotStyle}/>
+							<span className="rcb-dot" style={rcbDotStyle}/>
+							<span className="rcb-dot" style={rcbDotStyle}/>
 						</div>
 					</div>
 				</div>

--- a/src/components/ChatBotBody/ChatBotBody.tsx
+++ b/src/components/ChatBotBody/ChatBotBody.tsx
@@ -59,7 +59,17 @@ const ChatBotBody = ({
 	const bodyStyle: CSSProperties = {
 		...styles?.bodyStyle,
 		scrollbarWidth: settings.chatWindow?.showScrollbar ? "auto" : "none",
-	}
+	};
+
+	// styles for typing indicator
+	const rcbDot: CSSProperties = {
+		width: "8px",
+		height: "8px",
+		borderRadius: "50%",
+		backgroundColor: "#ccc",
+		marginRight: "4px",
+		animation: "rcb-typing 1s infinite"
+	};
 
 	// styles for user bubble
 	const userBubbleStyle: CSSProperties = {
@@ -273,9 +283,9 @@ const ChatBotBody = ({
 						className={`rcb-bot-message ${botBubbleEntryStyle}`}
 					>
 						<div className="rcb-typing-indicator">
-							<span className="rcb-dot"/>
-							<span className="rcb-dot"/>
-							<span className="rcb-dot"/>
+							<span style={rcbDot} className="rcb-dot"/>
+							<span style={rcbDot} className="rcb-dot"/>
+							<span style={rcbDot} className="rcb-dot"/>
 						</div>
 					</div>
 				</div>

--- a/src/components/ChatBotBody/ChatBotBody.tsx
+++ b/src/components/ChatBotBody/ChatBotBody.tsx
@@ -61,16 +61,6 @@ const ChatBotBody = ({
 		scrollbarWidth: settings.chatWindow?.showScrollbar ? "auto" : "none",
 	};
 
-	// styles for typing indicator
-	const rcbTypingIndicatorStyle: CSSProperties = {
-		...styles?.rcbTypingIndicatorStyle
-	};
-
-	// styles for rcb dot
-	const rcbDotStyle: CSSProperties = {
-		...styles?.rcbDotStyle
-	};
-
 	// styles for user bubble
 	const userBubbleStyle: CSSProperties = {
 		backgroundColor: settings.general?.primaryColor,
@@ -282,10 +272,10 @@ const ChatBotBody = ({
 						}}
 						className={`rcb-bot-message ${botBubbleEntryStyle}`}
 					>
-						<div className="rcb-typing-indicator" style={rcbTypingIndicatorStyle}>
-							<span className="rcb-dot" style={rcbDotStyle}/>
-							<span className="rcb-dot" style={rcbDotStyle}/>
-							<span className="rcb-dot" style={rcbDotStyle}/>
+						<div className="rcb-typing-indicator" style={{...styles?.rcbTypingIndicatorStyle}}>
+							<span className="rcb-dot" style={{...styles?.rcbDotStyle}}/>
+							<span className="rcb-dot" style={{...styles?.rcbDotStyle}}/>
+							<span className="rcb-dot" style={{...styles?.rcbDotStyle}}/>
 						</div>
 					</div>
 				</div>

--- a/src/constants/internal/DefaultStyles.tsx
+++ b/src/constants/internal/DefaultStyles.tsx
@@ -57,4 +57,6 @@ export const DefaultStyles: Styles = {
 	voiceIconStyle: {},
 	voiceIconDisabledStyle: {},
 	sendIconStyle: {},
+	rcbTypingIndicatorStyle: {},
+	rcbDotStyle: {},
 }

--- a/src/types/Styles.ts
+++ b/src/types/Styles.ts
@@ -57,4 +57,6 @@ export type Styles = {
 	voiceIconStyle?: React.CSSProperties;
 	voiceIconDisabledStyle?: React.CSSProperties;
 	sendIconStyle?: React.CSSProperties;
+	rcbTypingIndicatorStyle?: React.CSSProperties;
+	rcbDotStyle?: React.CSSProperties;
 }


### PR DESCRIPTION
#### Description

Added inline styles for "rcbDot" and  "rcbTypingIndicator" in ChatBotBody.tsx.

Closes issue #105

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)
- [x] Non breaking change (adding code that doesn't add additional functionality)

#### What is the proposed approach?

Added the styles in the "Styles.ts" and "DefaultStyles.tsx".

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)