### PR TITLE
feat: prevent sending in ChatInput while IME conversion is in progress

### DIFF
--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -126,7 +126,9 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 	 * @param event keyboard event
 	 */ 
 	const handleKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-		if (isComposing) return;
+		if (isComposing) {
+			return;
+		}
 		if (event.key === "Enter") {
 			if (event.shiftKey) {
 				if (!settings.chatInput?.allowNewline) {

--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -39,6 +39,9 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 	// tracks if chat input is focused
 	const [isFocused, setIsFocused] = useState<boolean>(false);
 
+	// tracks if text composition (like IME input) is in progress
+	const [isComposing, setIsComposing] = useState<boolean>(false);
+
 	// handles flow start
 	const { hasFlowStarted, setHasFlowStarted } = useFirstInteractionInternal();
 
@@ -104,11 +107,26 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 	};
 
 	/**
+	 * Handles composition start event on chat input.
+	 */
+	const handleCompositionStart = () => {
+		setIsComposing(true);
+	};
+
+	/**
+	 * Handles composition end event on chat input.
+	 */
+	const handleCompositionEnd = () => {
+		setIsComposing(false);
+	};
+
+	/**
 	 * Handles keyboard events and proceeds to submit user input if enter button is pressed.
 	 * 
 	 * @param event keyboard event
 	 */ 
 	const handleKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+		if (isComposing) return;
 		if (event.key === "Enter") {
 			if (event.shiftKey) {
 				if (!settings.chatInput?.allowNewline) {
@@ -177,6 +195,8 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 					onKeyDown={handleKeyDown}
 					onFocus={handleFocus}
 					onBlur={handleBlur}
+					onCompositionStart={handleCompositionStart}
+					onCompositionEnd={handleCompositionEnd}
 				/>
 				:
 				<textarea
@@ -191,6 +211,8 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 					onKeyDown={handleKeyDown}
 					onFocus={handleFocus}
 					onBlur={handleBlur}
+					onCompositionStart={handleCompositionStart}
+					onCompositionEnd={handleCompositionEnd}
 				/>
 			}
 			<div className="rcb-chat-input-button-container">


### PR DESCRIPTION
#### Description

Add an isComposing state to the ChatInput component to prevent events from being triggered when the Enter key is pressed during IME conversion

Closes #109 

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)