### PR TITLE
Feat: textarea value event emission

### DIFF
--- a/src/components/ChatBotInput/ChatBotInput.tsx
+++ b/src/components/ChatBotInput/ChatBotInput.tsx
@@ -16,6 +16,7 @@ import { useSettingsContext } from "../../context/SettingsContext";
 import { useStylesContext } from "../../context/StylesContext";
 
 import "./ChatBotInput.css";
+import { useTextArea } from "../../hooks/useTextArea";
 
 /**
  * Contains chat input field for user to enter messages.
@@ -47,6 +48,9 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 
 	// handles user input submission
 	const { handleSubmitText } = useSubmitInputInternal();
+
+	//handle textarea functionality
+	const { setTextAreaValue } = useTextArea();
 
 	// styles for text area
 	const textAreaStyle: React.CSSProperties = {
@@ -147,26 +151,9 @@ const ChatBotInput = ({ buttons }: { buttons: JSX.Element[] }) => {
 	 * @param event textarea change event
 	 */
 	const handleTextAreaValueChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-		if (textAreaDisabled && inputRef.current) {
-			// prevent input and keep current value
-			inputRef.current.value = "";
-			return;
-		}
 
 		if (inputRef.current) {
-			const characterLimit = settings.chatInput?.characterLimit
-			/*
-			* @params allowNewline Boolean
-			* allowNewline [true] Allow input values to contain line breaks "\n"
-			* allowNewline [false] Replace \n with a space
-			* */
-			const allowNewline = settings.chatInput?.allowNewline
-			const newInput = allowNewline ? event.target.value : event.target.value.replace(/\n/g, " ");
-			if (characterLimit != null && characterLimit >= 0 && newInput.length > characterLimit) {
-				inputRef.current.value = newInput.slice(0, characterLimit);
-			} else {
-				inputRef.current.value = newInput
-			}
+			setTextAreaValue(event.target.value)
 			setInputLength(inputRef.current.value.length);
 		}
 	};

--- a/src/constants/RcbEvent.ts
+++ b/src/constants/RcbEvent.ts
@@ -33,6 +33,9 @@ const RcbEvent = {
 	// user input submission
 	USER_SUBMIT_TEXT: "rcb-user-submit-text",
 	USER_UPLOAD_FILE: "rcb-user-upload-file",
+
+	// text area value change
+	TEXTAREA_CHANGE_VALUE: "rcb-textarea-change-value"
 }
 
 export { RcbEvent };

--- a/src/context/BotRefsContext.tsx
+++ b/src/context/BotRefsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef } from "react";
+import React, { createContext, useContext, useRef } from "react";
 
 import { Flow } from "../types/Flow";
 
@@ -9,6 +9,7 @@ type BotRefsContextType = {
 	botIdRef: React.RefObject<string>;
 	flowRef: React.RefObject<Flow>;
 	inputRef: React.RefObject<HTMLTextAreaElement | HTMLInputElement>;
+	prevInputRef: React.MutableRefObject<string>;
 	streamMessageMap: React.MutableRefObject<Map<string, string>>;
 	chatBodyRef: React.RefObject<HTMLDivElement>;
 	paramsInputRef: React.MutableRefObject<string>;
@@ -32,6 +33,7 @@ const BotRefsProvider = ({
 	const botIdRef = useRef<string>(id);
 	const flowRef = useRef<Flow>(initialFlow);
 	const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement>(null);
+	const prevInputRef = useRef<string>("");
 	const streamMessageMap = useRef<Map<string, string>>(new Map());
 	const chatBodyRef = useRef<HTMLDivElement>(null);
 	const paramsInputRef = useRef<string>("");
@@ -45,7 +47,8 @@ const BotRefsProvider = ({
 			streamMessageMap,
 			chatBodyRef,
 			paramsInputRef,
-			keepVoiceOnRef
+			keepVoiceOnRef,
+			prevInputRef
 		}}>
 			{children}
 		</BotRefsContext.Provider>

--- a/src/services/RcbEventService.tsx
+++ b/src/services/RcbEventService.tsx
@@ -21,7 +21,8 @@ const cancellableMap = {
 	[RcbEvent.SHOW_TOAST]: true,
 	[RcbEvent.DISMISS_TOAST]: true,
 	[RcbEvent.USER_SUBMIT_TEXT]: true,
-	[RcbEvent.USER_UPLOAD_FILE]: true
+	[RcbEvent.USER_UPLOAD_FILE]: true,
+	[RcbEvent.TEXTAREA_CHANGE_VALUE]: true
 }
 
 /**

--- a/src/services/RcbEventService.tsx
+++ b/src/services/RcbEventService.tsx
@@ -36,7 +36,7 @@ export const emitRcbEvent = (eventName: typeof RcbEvent[keyof typeof RcbEvent], 
 	// Create a custom event with the provided name and detail
 	const event: RcbBaseEvent = new CustomEvent(eventName, {
 		detail: eventDetail,
-		cancelable: cancellableMap.eventName,
+		cancelable: cancellableMap[eventName],
 	}) as RcbBaseEvent<typeof data, EventDetail>;
 
 	event.data = data;

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -148,5 +148,6 @@ export type Settings = {
 		rcbDismissToast?: boolean;
 		rcbUserSubmitText?: boolean;
 		rcbUserUploadFile?: boolean;
+		rcbTextareaChangeValue?: boolean;
 	}
 }

--- a/src/types/events/RcbTextareaChangeValue.ts
+++ b/src/types/events/RcbTextareaChangeValue.ts
@@ -1,0 +1,9 @@
+import { RcbBaseEvent } from "../internal/events/RcbBaseEvent";
+
+/**
+ * Defines the data available for stop stream message event.
+ */
+export type RcbTextareaChangeValueEvent = RcbBaseEvent<{
+    currValue: string;
+    prevValue: string;
+}>;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -16,6 +16,7 @@ import { RcbDismissToastEvent } from "../src/types/events/RcbDismissToastEvent";
 import { RcbUserSubmitTextEvent } from "../src/types/events/RcbUserSubmitTextEvent";
 import { RcbUserUploadFileEvent } from "../src/types/events/RcbUserUploadFileEvent";
 import { RcbEvent } from "../src/constants/RcbEvent";
+import { RcbTextareaChangeValueEvent } from "../src/types/events/RcbTextareaChangeValue";
 
 declare global {
 	interface Navigator {
@@ -72,5 +73,8 @@ declare global {
 		// user input submission
 		"rcb-user-submit-text": RcbUserSubmitTextEvent;
 		"rcb-user-upload-file": RcbUserUploadFileEvent;
+
+		// textarea change value
+		"rcb-textarea-change-value": RcbTextareaChangeValueEvent;
 	}
 }


### PR DESCRIPTION
#### Description

By adhering to the pattern with the emission of the other events, textarea-change-value event is emitted internally inside `useTextAreaInternal` at the setting of the value. All the checks inside the Input component was moved there, and if everything is passed the event is emitted.

Closes #111

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Using the `inputRef` as the single source of truth, the addition of another ref to store the old value was added to store the old value.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)