### PR TITLE
fix: removeMessage not working due to outdated messages state

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
 	},
 	"plugins": [
 		"@typescript-eslint",
-		"react"
+		"react",
+		"react-hooks"
 	],
 	"extends": [
 		"eslint:recommended",
@@ -20,6 +21,8 @@
 		"indent": ["error", "tab"],
 		"react/jsx-indent": ["error", "tab"],
 		"react/jsx-indent-props": ["error", "tab"],
+		"react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
 		"max-len": ["error", { "code": 120 }]
 	}
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,7 @@
 		"react/jsx-indent": ["error", "tab"],
 		"react/jsx-indent-props": ["error", "tab"],
 		"react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
+		"react-hooks/exhaustive-deps": "warn",
 		"max-len": ["error", { "code": 120 }]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2",
+        "eslint-plugin-react-hooks": "^4.6.2",
         "husky": "^8.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3004,6 +3005,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "husky": "^8.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/hooks/internal/useMessagesInternal.ts
+++ b/src/hooks/internal/useMessagesInternal.ts
@@ -39,7 +39,7 @@ export const useMessagesInternal = () => {
 	 * @param useMarkup boolean indicating whether markup is used
 	 */
 	const simulateStream = useCallback(async (message: Message, streamSpeed: number, useMarkup: boolean) => {
-	// stop bot typing when simulating stream
+		// stop bot typing when simulating stream
 		setIsBotTyping(false);
 
 		// set an initial empty message to be used for streaming
@@ -87,7 +87,7 @@ export const useMessagesInternal = () => {
 		await simStreamDoneTask;
 		streamMessageMap.current.delete("bot");
 		saveChatHistory(messages);
-	}, [messages, setIsBotTyping, setMessages, streamMessageMap]);
+	}, [messages, streamMessageMap]);
 
 	/**
 	 * Injects a message at the end of the messages array.
@@ -134,7 +134,7 @@ export const useMessagesInternal = () => {
 		}
 
 		return message.id;
-	}, [settings, audioToggledOn, isChatWindowOpen, setUnreadCount, callRcbEvent, simulateStream, setMessages]);
+	}, [settings, audioToggledOn, isChatWindowOpen, callRcbEvent, simulateStream]);
 
 	/**
 	 * Removes a message with the given id.
@@ -158,7 +158,7 @@ export const useMessagesInternal = () => {
 		setMessages((prevMessages) => prevMessages.filter(message => message.id !== messageId));
 		setUnreadCount((prevCount) => Math.max(prevCount - 1, 0));
 		return messageId;
-	}, [callRcbEvent, messages, setMessages, setUnreadCount, settings.event?.rcbRemoveMessage]);
+	}, [callRcbEvent, messages, settings.event?.rcbRemoveMessage]);
 
 	/**
 	 * Streams data into the last message at the end of the messages array with given type.
@@ -211,8 +211,7 @@ export const useMessagesInternal = () => {
 			return updatedMessages;
 		});
 		return streamMessageMap.current.get(sender) || null;
-	},[callRcbEvent, setIsBotTyping, setMessages, setUnreadCount, settings.event?.rcbChunkStreamMessage,
-		settings.event?.rcbStartStreamMessage, streamMessageMap]);
+	},[callRcbEvent, settings.event?.rcbChunkStreamMessage, settings.event?.rcbStartStreamMessage, streamMessageMap]);
 
 	/**
 	 * Sets the streaming mode of the chatbot.

--- a/src/hooks/internal/useMessagesInternal.ts
+++ b/src/hooks/internal/useMessagesInternal.ts
@@ -32,6 +32,64 @@ export const useMessagesInternal = () => {
 	const { callRcbEvent } = useRcbEventInternal();
 
 	/**
+	 * Simulates the streaming of a message from the bot.
+	 * 
+	 * @param message message to stream
+	 * @param streamSpeed speed to stream the message
+	 * @param useMarkup boolean indicating whether markup is used
+	 */
+	const simulateStream = useCallback(async (message: Message, streamSpeed: number, useMarkup: boolean) => {
+	// stop bot typing when simulating stream
+		setIsBotTyping(false);
+
+		// set an initial empty message to be used for streaming
+		setMessages(prevMessages => [...prevMessages, message]);
+		streamMessageMap.current.set("bot", message.id);
+
+		// initialize default message to empty with stream index position 0
+		let streamMessage = message.content as string | string[];
+		if (useMarkup) {
+			streamMessage = parseMarkupMessage(streamMessage as string);
+		}
+		let streamIndex = 0;
+		const endStreamIndex = streamMessage.length;
+		message.content = "";
+
+		const simStreamDoneTask: Promise<void> = new Promise(resolve => {
+			const intervalId = setInterval(() => {
+			// consider streaming done once end index is reached or exceeded
+			// when streaming is done, remove task and resolve the promise
+				if (streamIndex >= endStreamIndex) {
+					clearInterval(intervalId);
+					resolve();
+					return;
+				}
+
+				setMessages((prevMessages) => {
+					const updatedMessages = [...prevMessages];
+					for (let i = updatedMessages.length - 1; i >= 0; i--) {
+						if (updatedMessages[i].sender === message.sender
+						&& typeof updatedMessages[i].content === "string") {
+							const character = streamMessage[streamIndex];
+							if (character) {
+								message.content += character;
+								updatedMessages[i] = message;
+							}
+							streamIndex++;
+							break;
+						}
+					}
+					return updatedMessages;
+				});
+			}, streamSpeed);
+		});
+
+		await simStreamDoneTask;
+		streamMessageMap.current.delete("bot");
+		saveChatHistory(messages);
+	}, [messages, setIsBotTyping, setMessages, streamMessageMap]);
+
+	/**
 	 * Injects a message at the end of the messages array.
 	 * 
 	 * @param content message content to inject
@@ -76,7 +134,7 @@ export const useMessagesInternal = () => {
 		}
 
 		return message.id;
-	}, [settings, audioToggledOn, callRcbEvent]);
+	}, [settings, audioToggledOn, isChatWindowOpen, setUnreadCount, callRcbEvent, simulateStream, setMessages]);
 
 	/**
 	 * Removes a message with the given id.
@@ -100,65 +158,7 @@ export const useMessagesInternal = () => {
 		setMessages((prevMessages) => prevMessages.filter(message => message.id !== messageId));
 		setUnreadCount((prevCount) => Math.max(prevCount - 1, 0));
 		return messageId;
-	}, []);
-
-	/**
-	 * Simulates the streaming of a message from the bot.
-	 * 
-	 * @param message message to stream
-	 * @param streamSpeed speed to stream the message
-	 * @param useMarkup boolean indicating whether markup is used
-	 */
-	const simulateStream = useCallback(async (message: Message, streamSpeed: number, useMarkup: boolean) => {
-		// stop bot typing when simulating stream
-		setIsBotTyping(false);
-
-		// set an initial empty message to be used for streaming
-		setMessages(prevMessages => [...prevMessages, message]);
-		streamMessageMap.current.set("bot", message.id);
-
-		// initialize default message to empty with stream index position 0
-		let streamMessage = message.content as string | string[];
-		if (useMarkup) {
-			streamMessage = parseMarkupMessage(streamMessage as string);
-		}
-		let streamIndex = 0;
-		const endStreamIndex = streamMessage.length;
-		message.content = "";
-
-		const simStreamDoneTask: Promise<void> = new Promise(resolve => {
-			const intervalId = setInterval(() => {
-				// consider streaming done once end index is reached or exceeded
-				// when streaming is done, remove task and resolve the promise
-				if (streamIndex >= endStreamIndex) {
-					clearInterval(intervalId);
-					resolve();
-					return;
-				}
-
-				setMessages((prevMessages) => {
-					const updatedMessages = [...prevMessages];
-					for (let i = updatedMessages.length - 1; i >= 0; i--) {
-						if (updatedMessages[i].sender === message.sender
-							&& typeof updatedMessages[i].content === "string") {
-							const character = streamMessage[streamIndex];
-							if (character) {
-								message.content += character;
-								updatedMessages[i] = message;
-							}
-							streamIndex++;
-							break;
-						}
-					}
-					return updatedMessages;
-				});
-			}, streamSpeed);
-		});
-
-		await simStreamDoneTask;
-		streamMessageMap.current.delete("bot");
-		saveChatHistory(messages);
-	}, []);
+	}, [callRcbEvent, messages, setMessages, setUnreadCount, settings.event?.rcbRemoveMessage]);
 
 	/**
 	 * Streams data into the last message at the end of the messages array with given type.
@@ -211,7 +211,8 @@ export const useMessagesInternal = () => {
 			return updatedMessages;
 		});
 		return streamMessageMap.current.get(sender) || null;
-	},[]);
+	},[callRcbEvent, setIsBotTyping, setMessages, setUnreadCount, settings.event?.rcbChunkStreamMessage,
+		settings.event?.rcbStartStreamMessage, streamMessageMap]);
 
 	/**
 	 * Sets the streaming mode of the chatbot.
@@ -248,7 +249,7 @@ export const useMessagesInternal = () => {
 		streamMessageMap.current.delete(sender);
 		saveChatHistory(messages);
 		return true;
-	}, [messages])
+	}, [callRcbEvent, messages, settings.event?.rcbStopStreamMessage, streamMessageMap])
 
 	return {
 		endStreamMessage,

--- a/src/hooks/internal/useSubmitInputInternal.ts
+++ b/src/hooks/internal/useSubmitInputInternal.ts
@@ -165,11 +165,9 @@ export const useSubmitInputInternal = () => {
 				setIsBotTyping(false);
 			}
 		}, settings.chatInput?.botDelay);
-	}, [timeoutId, paramsInputRef, chatBodyRef, inputRef, settings.chatInput?.blockSpam, settings.chatInput?.botDelay,
-		settings.chatInput?.disabled, keepVoiceOnRef, voiceToggledOn, syncVoice, setTextAreaSensitiveMode,
-		handleSendUserInput, setTextAreaValue, setInputLength, setTextAreaDisabled, setIsBotTyping, getPrevPath,
-		getCurrPath, goToPath, injectMessage, streamMessage, removeMessage, endStreamMessage, openChat, showToast,
-		dismissToast, flowRef, setBlockAllowsAttachment]);
+	}, [timeoutId, settings.chatInput?.blockSpam, settings.chatInput?.botDelay, settings.chatInput?.disabled,
+		keepVoiceOnRef, voiceToggledOn, syncVoice, handleSendUserInput, getPrevPath, getCurrPath, goToPath,
+		injectMessage, streamMessage, removeMessage, endStreamMessage, openChat, showToast, dismissToast, flowRef]);
 
 	/**
 	 * Handles submission of user input via enter key or send button.

--- a/src/hooks/internal/useSubmitInputInternal.ts
+++ b/src/hooks/internal/useSubmitInputInternal.ts
@@ -26,7 +26,7 @@ export const useSubmitInputInternal = () => {
 	const { endStreamMessage, injectMessage, removeMessage, streamMessage } = useMessagesInternal();
 
 	// handles paths
-	const { getCurrPath, getPrevPath, goToPath, setPaths } = usePathsInternal();
+	const { getCurrPath, getPrevPath, goToPath } = usePathsInternal();
 
 	// handles bot states
 	const {
@@ -165,9 +165,11 @@ export const useSubmitInputInternal = () => {
 				setIsBotTyping(false);
 			}
 		}, settings.chatInput?.botDelay);
-	}, [timeoutId, voiceToggledOn, settings, flowRef, getPrevPath, injectMessage, streamMessage, openChat,
-		postProcessBlock, setPaths, handleSendUserInput, showToast
-	]);
+	}, [timeoutId, paramsInputRef, chatBodyRef, inputRef, settings.chatInput?.blockSpam, settings.chatInput?.botDelay,
+		settings.chatInput?.disabled, keepVoiceOnRef, voiceToggledOn, syncVoice, setTextAreaSensitiveMode,
+		handleSendUserInput, setTextAreaValue, setInputLength, setTextAreaDisabled, setIsBotTyping, getPrevPath,
+		getCurrPath, goToPath, injectMessage, streamMessage, removeMessage, endStreamMessage, openChat, showToast,
+		dismissToast, flowRef, setBlockAllowsAttachment]);
 
 	/**
 	 * Handles submission of user input via enter key or send button.
@@ -191,7 +193,7 @@ export const useSubmitInputInternal = () => {
 			return;
 		}
 		handleActionInput(currPath, inputText, sendInChat);
-	}, [getCurrPath, handleActionInput, setInputLength])
+	}, [callRcbEvent, getCurrPath, handleActionInput, inputRef, settings.event?.rcbUserSubmitText])
 
 	return { handleSubmitText }
 };


### PR DESCRIPTION
#### Description

The `removeMessage` from `useMessages()` and `params` doesn't work because the `messages` are not updated within the `useCallback` wrapper of this function.

Closes #(issue)

#### What change does this PR introduce?

- added `eslint-plugin-react-hooks` devDependecy
- updated .eslintrc config to use the react-hooks and display warnings related to react hooks
- with the above configuration, the editor (VSCode) started to provide suggestions related to missing react hooks dependencies
- added the missing dependencies for `removeMessage` function
- added missing dependencies for other useCallback functions from the `useMessagesInternal.ts` and `useSubmitInputInternal.ts` files
- moved the `simulateStream` function before `injectMessage` since it was used before it was defined

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Always add the required dependencies for a react hook.
The new eslint plugin for react hooks will help development by providing warnings when writing new code and when executing the lint command.  

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)