### PR TITLE
fix: textArea is disabled after chatHistory is loaded

### DIFF
--- a/__tests__/hooks/internal/useChatHistoryInternal.test.ts
+++ b/__tests__/hooks/internal/useChatHistoryInternal.test.ts
@@ -27,25 +27,25 @@ describe("useChatHistoryInternal Hook", () => {
 
 	// initial values
 	const initialIsLoadingChatHistory = false;
-    const initialChatHistory = [
-        {
-            id: generateSecureUUID(),
-            sender: "user",
-            content: "Hello",
-            type: "string",
-            timestamp: new Date().toUTCString()
-        },
-        {
-            id: generateSecureUUID(),
-            sender: "bot",
-            content: "Hi there!",
-            type: "string",
-            timestamp: new Date().toUTCString()
-        },
-    ];
+	const initialChatHistory = [
+		{
+			id: generateSecureUUID(),
+			sender: "user",
+			content: "Hello",
+			type: "string",
+			timestamp: new Date().toUTCString()
+		},
+		{
+			id: generateSecureUUID(),
+			sender: "bot",
+			content: "Hi there!",
+			type: "string",
+			timestamp: new Date().toUTCString()
+		},
+	];
 
 	it("should load chat history correctly, change state and emit rcb-load-chat-history event", async () => {
-        // mocks rcb event handler
+		// mocks rcb event handler
 		const callRcbEventMock = jest.fn().mockReturnValue({ defaultPrevented: false });
 		mockUseRcbEventInternal.mockReturnValue({
 			callRcbEvent: callRcbEventMock,
@@ -56,9 +56,8 @@ describe("useChatHistoryInternal Hook", () => {
 
 		// mocks loadChatHistory to resolve successfully
 		mockLoadChatHistory.mockImplementation(
-			(settings, styles, chatHistory, setMessages, prevTextAreaDisabled, setTextAreaDisabled) => {
+			(settings, styles, chatHistory, setMessages) => {
 				setMessages(chatHistory);
-				setTextAreaDisabled(false);
 				return Promise.resolve();
 			}
 		);
@@ -82,20 +81,18 @@ describe("useChatHistoryInternal Hook", () => {
 		// checks if get history messages was called
 		expect(mockGetHistoryMessages).toHaveBeenCalledTimes(1);
 
-        // checks if callRcbEvent was called with rcb-load-chat-history and correct arguments
+		// checks if callRcbEvent was called with rcb-load-chat-history and correct arguments
 		expect(callRcbEventMock).toHaveBeenCalledWith(RcbEvent.LOAD_CHAT_HISTORY, {});
-		
-        // checks if load chat history was called
-        expect(mockLoadChatHistory).toHaveBeenCalledWith(
+
+		// checks if load chat history was called
+		expect(mockLoadChatHistory).toHaveBeenCalledWith(
 			MockDefaultSettings,
 			expect.any(Object),
 			initialChatHistory,
 			expect.any(Function),
-			expect.any(Boolean),
-			expect.any(Function)
 		);
 
-        // checks if history is being loaded
+		// checks if history is being loaded
 		expect(result.current.isLoadingChatHistory).toBe(true);
 	});
 
@@ -125,13 +122,13 @@ describe("useChatHistoryInternal Hook", () => {
 		// checks if get history messages was called
 		expect(mockGetHistoryMessages).toHaveBeenCalledTimes(1);
 
-        // checks if callRcbEvent was called with rcb-load-chat-history and correct arguments
+		// checks if callRcbEvent was called with rcb-load-chat-history and correct arguments
 		expect(callRcbEventMock).toHaveBeenCalledWith(RcbEvent.LOAD_CHAT_HISTORY, {});
 
-        // checks if load chat history was not called
+		// checks if load chat history was not called
 		expect(mockLoadChatHistory).not.toHaveBeenCalled();
 
-        // checks if history is being loaded
+		// checks if history is being loaded
 		expect(result.current.isLoadingChatHistory).toBe(false);
 	});
 });

--- a/src/hooks/internal/useChatHistoryInternal.ts
+++ b/src/hooks/internal/useChatHistoryInternal.ts
@@ -25,8 +25,6 @@ export const useChatHistoryInternal = () => {
 	const {
 		isLoadingChatHistory,
 		setIsLoadingChatHistory,
-		textAreaDisabled,
-		setTextAreaDisabled
 	} = useBotStatesContext();
 
 	// handles rcb events
@@ -51,10 +49,10 @@ export const useChatHistoryInternal = () => {
 			}
 		}
 		setIsLoadingChatHistory(true);
-		const prevTextAreaDisabled = textAreaDisabled;
-		setTextAreaDisabled(true);
-		loadChatHistory(settings, styles, chatHistory, setMessages, prevTextAreaDisabled, setTextAreaDisabled);
-	}, [settings, styles, setMessages, setTextAreaDisabled]);
+		// const prevTextAreaDisabled = textAreaDisabled;
+		// setTextAreaDisabled(true);
+		loadChatHistory(settings, styles, chatHistory, setMessages);
+	}, [settings, styles, setMessages]);
 
 	return { isLoadingChatHistory, setIsLoadingChatHistory, showChatHistory };
 };

--- a/src/hooks/internal/useChatHistoryInternal.ts
+++ b/src/hooks/internal/useChatHistoryInternal.ts
@@ -49,8 +49,6 @@ export const useChatHistoryInternal = () => {
 			}
 		}
 		setIsLoadingChatHistory(true);
-		// const prevTextAreaDisabled = textAreaDisabled;
-		// setTextAreaDisabled(true);
 		loadChatHistory(settings, styles, chatHistory, setMessages);
 	}, [settings, styles, setMessages]);
 

--- a/src/services/ChatHistoryService.tsx
+++ b/src/services/ChatHistoryService.tsx
@@ -128,8 +128,7 @@ const parseMessageToString = (message: Message) => {
  * @param setTextAreaDisabled setter for enabling/disabling user text area
  */
 const loadChatHistory = (settings: Settings, styles: Styles, chatHistory: Message[],
-	setMessages: Dispatch<SetStateAction<Message[]>>, prevTextAreaDisabled: boolean,
-	setTextAreaDisabled: Dispatch<SetStateAction<boolean>>) => {
+	setMessages: Dispatch<SetStateAction<Message[]>>) => {
 
 	historyLoaded = true;
 	if (chatHistory != null) {
@@ -160,7 +159,6 @@ const loadChatHistory = (settings: Settings, styles: Styles, chatHistory: Messag
 					}
 					return [...parsedMessages, lineBreakMessage, ...prevMessages];
 				});
-				setTextAreaDisabled(prevTextAreaDisabled ?? settings.chatInput?.disabled ?? false);
 			}, 500)
 		} catch {
 			// remove chat history on error (to address corrupted storage values)


### PR DESCRIPTION
#### Description

`setTextAreaDisabled(settings.chatInput?.disabled)` is not called when the chatHistory is loaded.

Closes [#172](https://github.com/tjtanjin/react-chatbotify/issues/172)

#### What change does this PR introduce?

- Added a useState variable in BotStatesContext.tsx to track chatHistory being loaded.
- Added a function call setIsChatHistoryLoaded(true) after setIsLoadingChatHistory(false).
- Added `useEffect()` to call `setTextAreaDisabled(false)` after chatHistory is done loading.

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

- Implement checking when chatHistory is done loading with a useState variable.
- Enable textArea when chatHistory is done loading.
- isChatHistoryLoaded stays remain true because there is no feature to hide the chat history.
- isChatHistoryLoaded can be set to false with hide chat history button (possible feature).

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)