### PR TITLE
Test: chatdisabledProcessor

### DIFF
--- a/__tests__/services/BlockService/ChatDisabledProcessor.test.ts
+++ b/__tests__/services/BlockService/ChatDisabledProcessor.test.ts
@@ -1,0 +1,113 @@
+import { processChatDisabled } from "../../../src/services/BlockService/ChatDisabledProcessor";
+import { Block } from "../../../src/types/Block";
+import { Params } from "../../../src/types/Params";
+
+
+describe('processChatDisabled', () => {
+	let mockSetTextAreaDisabled: jest.Mock;
+	let block: Block;
+	let params: Params;
+
+	beforeEach(() => {
+		mockSetTextAreaDisabled = jest.fn();
+		params = {
+			userInput: "test input",
+			currPath: null, 
+			prevPath: null, 
+			goToPath: jest.fn(), 
+			setTextAreaValue: jest.fn(),
+			injectMessage: jest.fn(() => Promise.resolve(null)),
+			streamMessage: jest.fn(() => Promise.resolve(null)),
+			removeMessage: jest.fn(() => Promise.resolve(null)),
+			endStreamMessage: jest.fn(() => Promise.resolve(true)),
+			showToast: jest.fn(),
+			dismissToast: jest.fn(() => null),
+			openChat: jest.fn(),
+			files: undefined, 
+		} as Params;
+	});
+
+	it('should do nothing if block.chatDisabled is null', async () => {
+		block = { chatDisabled: null } as Block;
+
+		await processChatDisabled(block, mockSetTextAreaDisabled, params);
+
+		expect(mockSetTextAreaDisabled).not.toHaveBeenCalled();
+	});
+
+	it('should call setTextAreaDisabled with the boolean value if block.chatDisabled is a boolean', async () => {
+		block = { chatDisabled: true } as Block;
+
+		await processChatDisabled(block, mockSetTextAreaDisabled, params);
+
+		expect(mockSetTextAreaDisabled).toHaveBeenCalledWith(true);
+	});
+
+	it('should call setTextAreaDisabled with the return value of a func if block.chatDisabled is a func', async () => {
+		block = {
+			chatDisabled: jest.fn(() => false)
+		} as unknown as Block;
+
+		await processChatDisabled(block, mockSetTextAreaDisabled, params);
+
+		expect(block.chatDisabled).toHaveBeenCalledWith(params);
+		expect(mockSetTextAreaDisabled).toHaveBeenCalledWith(false);
+	});
+
+	it('should await the promise if block.chatDisabled is a function that returns a promise', async () => {
+		block = {
+			chatDisabled: jest.fn(() => Promise.resolve(true))
+		} as unknown as Block;
+
+		await processChatDisabled(block, mockSetTextAreaDisabled, params);
+
+		expect(block.chatDisabled).toHaveBeenCalledWith(params);
+		expect(mockSetTextAreaDisabled).toHaveBeenCalledWith(true);
+	});
+
+	it('should call setTextAreaDisabled with null if block.chatDisabled is a function returning null', async () => {
+		block = {
+			chatDisabled: jest.fn(() => null)
+		} as unknown as Block;
+    
+		await processChatDisabled(block, mockSetTextAreaDisabled, params);
+    
+		expect(block.chatDisabled).toHaveBeenCalledWith(params);
+		expect(mockSetTextAreaDisabled).toHaveBeenCalledWith(null);
+	});
+    
+	it('should handle errors when block.chatDisabled function throws an error', async () => {
+		block = {
+			chatDisabled: jest.fn(() => {
+				throw new Error('Test error');
+			})
+		} as unknown as Block;
+    
+		await expect(processChatDisabled(block, mockSetTextAreaDisabled, params))
+			.rejects
+			.toThrow('Test error');
+    
+		expect(mockSetTextAreaDisabled).not.toHaveBeenCalled();
+	});
+    
+	it('should handle promise rejection if block.chatDisabled function returns a rejected promise', async () => {
+		block = {
+			chatDisabled: jest.fn(() => Promise.reject('Promise rejection'))
+		} as unknown as Block;
+    
+		await expect(processChatDisabled(block, mockSetTextAreaDisabled, params))
+			.rejects
+			.toEqual('Promise rejection');
+    
+		expect(mockSetTextAreaDisabled).not.toHaveBeenCalled();
+	});
+    
+	it('should handle unexpected data type for block.chatDisabled (e.g., an object)', async () => {
+		block = { chatDisabled: {} } as unknown as Block;
+    
+		await processChatDisabled(block, mockSetTextAreaDisabled, params);
+    
+		// Expect that setTextAreaDisabled is called with an invalid type, in this case '{}'
+		expect(mockSetTextAreaDisabled).toHaveBeenCalledWith({});
+	});
+});

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -19,7 +19,7 @@ export type Block = {
 		((params: Params) => Promise<{items: Array<string>, max?: number, min?: number, sendOutput?: boolean, reusable?: boolean}>);
 	component?: JSX.Element | void | ((params: Params) => JSX.Element | void) |
 	((params: Params) => Promise<JSX.Element | void>);
-	chatDisabled?: boolean | ((params: Params) => boolean) | ((params: Params) => Promise<boolean>);
+	chatDisabled?: boolean | ((params: Params) => boolean) | ((params: Params) => Promise<boolean>) | null;
 	isSensitive?: boolean | ((params: Params) => boolean) | ((params: Params) => Promise<boolean>);
 	transition?: number | {duration: number, interruptable?: boolean} | void | 
 		((params: Params) =>  number | {duration: number, interruptable?: boolean} | void) |


### PR DESCRIPTION
#### Description

Unit test for ChatDisabledProcessor

Closes #(issue)

#169 

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Tested for the following
- Do nothing is block.chatDisabled is null
- Call setTextAreaDisabled with the boolean value if block.chatDisabled is a boolean
- Call setTextAreaDisabled with the return value of a function if block.chatDisabled is a function
- Await the promise if block.chatDisabled is a function that returns a promise
- Call setTextAreaDisabled with null if block.chatDisabled is a function returning null
- Handle errors when block.chatDisabled function throws an error
- Handle promise rejection if block.chatDisabled function returns a rejected promise
- Handle unexpected data type for block.chatDisabled (e.g., an object)

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)