### PR TITLE
fix: unit test warnings and code style lint issues

### DIFF
--- a/__tests__/components/ChatHistoryButton/ChatHistoryButton.test.tsx
+++ b/__tests__/components/ChatHistoryButton/ChatHistoryButton.test.tsx
@@ -27,7 +27,7 @@ describe("ChatHistoryButton", () => {
 	};
 
 	const mockStyles = {
-		chatHistoryButtonStyle: { backgroundColor: "#ffffff", border: "1px solid #ccc" },
+		chatHistoryButtonStyle: { backgroundColor: "#ffffff", border: "1px solid", borderColor: "#ccc" },
 		chatHistoryButtonHoveredStyle: { backgroundColor: "#f0f0f0" },
 	};
 
@@ -49,7 +49,7 @@ describe("ChatHistoryButton", () => {
 		// Verify the button's initial styles
 		const button = screen.getByRole("button");
 		expect(button).toHaveStyle("background-color: #ffffff");
-		expect(button).toHaveStyle("border: 1px solid #ccc");
+		expect(button).toHaveStyle("border: 1px solid; border-color: #ccc");
 	});
 
 	it("changes styles when hovered", () => {

--- a/__tests__/components/buttons/ChatBotButton.test.tsx
+++ b/__tests__/components/buttons/ChatBotButton.test.tsx
@@ -8,30 +8,30 @@ import { DefaultSettings } from "../../../src/constants/internal/DefaultSettings
 
 // Helper function to render ChatBotButton within TestChatBotProvider
 const renderChatBotButton = () => {
-  return render(
-    <TestChatBotProvider initialSettings={DefaultSettings}>
-      <ChatBotButton />  
-    </TestChatBotProvider>
-  );
+	return render(
+		<TestChatBotProvider initialSettings={DefaultSettings}>
+			<ChatBotButton />  
+		</TestChatBotProvider>
+	);
 };
 
 describe('ChatBotButton', () => {
-  it('renders ChatBotButton correctly', () => {
-    renderChatBotButton();
-    const button = screen.getByRole('button');
-    expect(button).toBeInTheDocument();
-  });
+	it('renders ChatBotButton correctly', () => {
+		renderChatBotButton();
+		const button = screen.getByRole('button');
+		expect(button).toBeInTheDocument();
+	});
 
-  // Mock visibility toggle function (assuming it's triggered by a button click)
-  it('toggles visibility classes correctly based on internal function', () => {
-    renderChatBotButton();
-    const button = screen.getByRole('button');
+	// Mock visibility toggle function (assuming it's triggered by a button click)
+	it('toggles visibility classes correctly based on internal function', () => {
+		renderChatBotButton();
+		const button = screen.getByRole('button');
 
-    // Initially visible
-    expect(button).toHaveClass('rcb-button-show');
+		// Initially visible
+		expect(button).toHaveClass('rcb-button-show');
 
-    // Simulate state change or function that hides the button
-    fireEvent.click(button); // Assuming the button click triggers visibility toggle
-    expect(button).toHaveClass('rcb-button-hide');  // Check if the class changes to hidden
-  });
+		// Simulate state change or function that hides the button
+		fireEvent.click(button); // Assuming the button click triggers visibility toggle
+		expect(button).toHaveClass('rcb-button-hide');  // Check if the class changes to hidden
+	});
 });


### PR DESCRIPTION
#### Description

- Resolved warnings in ChatHistoryButton unit test
- Changed from space to tab indentation in ChatBotButton unit test

Related to these issues:

- ChatHistoryButton unit test - [#146](https://github.com/tjtanjin/react-chatbotify/issues/146)
- ChatBotButton unit test - [#145](https://github.com/tjtanjin/react-chatbotify/issues/145)

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)
- [x] Resolve unit test warnings
- [x] Fix lint issue

#### What is the proposed approach?

- `Warning: Removing a style property during rerender (borderColor) when a conflicting property is set (border) can lead to styling bugs.` fixed this warning by spliting border css to border and borderColor
- Change ChatBotButton unit test intentation from space to Tab

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)