### PR TITLE
Test: Add unit test cases for IsSensitiveProcessor

### DIFF
--- a/__tests__/services/BlockService/IsSensitiveProcessor.test.ts
+++ b/__tests__/services/BlockService/IsSensitiveProcessor.test.ts
@@ -1,0 +1,90 @@
+import { processIsSensitive } from "../../../src/services/BlockService/IsSensitiveProcessor";
+import { Block } from "../../../src/types/Block";
+import { Params } from "../../../src/types/Params";
+
+describe("processIsSensitive", () => {
+    let mockSetTextAreaSensitiveMode: jest.Mock;
+    let mockBlock: Block;
+    let mockParams: Params;
+
+    beforeEach(() => {
+        mockSetTextAreaSensitiveMode = jest.fn();
+        mockBlock = {
+            isSensitive: false,
+        };
+        mockParams = {} as Params;
+    });
+
+    it("should disable sensitive mode if block.isSensitive is undefined", async () => {
+        mockBlock.isSensitive = undefined;
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(false);
+    });
+
+    it("should disable sensitive mode if block.isSensitive is false", async () => {
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(false);
+    });
+
+    it("should enable sensitive mode if block.isSensitive is true", async () => {
+        mockBlock.isSensitive = true;
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(true);
+    });
+
+    it("should enable sensitive mode if isSensitive is a function returning a boolean true", async () => {
+        mockBlock.isSensitive = jest.fn().mockReturnValue(true);
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(true);
+        expect(mockBlock.isSensitive).toHaveBeenCalledWith(mockParams);
+    });
+
+    it("should disable sensitive mode if isSensitive is a function returning a boolean false", async () => {
+        mockBlock.isSensitive = jest.fn().mockReturnValue(false);
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(false);
+        expect(mockBlock.isSensitive).toHaveBeenCalledWith(mockParams);
+    });
+
+    it("should enbale sensitive mode if isSensitive is a function returning a Promise with true", async () => {
+        mockBlock.isSensitive = jest.fn().mockResolvedValue(true);
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(true);
+        expect(mockBlock.isSensitive).toHaveBeenCalledWith(mockParams);
+    });
+
+    it("should disable sensitive mode if isSensitive is a function returning a Promise with false", async () => {
+        mockBlock.isSensitive = jest.fn().mockResolvedValue(false);
+        await processIsSensitive(
+            mockBlock,
+            mockSetTextAreaSensitiveMode,
+            mockParams
+        );
+        expect(mockSetTextAreaSensitiveMode).toHaveBeenCalledWith(false);
+        expect(mockBlock.isSensitive).toHaveBeenCalledWith(mockParams);
+    });
+});


### PR DESCRIPTION
#### Description

This PR adds unit tests for the `processIsSensitive` function within the `BlockService`. Additionally, it includes mocks for `params` and handles scenarios where `isSensitive` can be undefined, a boolean, a function, or a Promise.

Closes #183
#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

This PR introduces unit tests for the `processIsSensitive` function, focusing on testing how the function handles different types for the isSensitive property (boolean, function, Promise, and undefined). The approach includes mocking params and ensuring that asynchronous and synchronous behaviors are properly tested. The function's logic is validated to ensure it correctly sets the `setTextAreaSensitiveMode` based on various return types from `isSensitive`.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)