### PR TITLE
fix: Infinite runLoadConifg() call when using ChatBotProvider

### DIFF
--- a/src/components/ChatBot.tsx
+++ b/src/components/ChatBot.tsx
@@ -58,7 +58,8 @@ const ChatBot = ({
 	const renderChatBot = () => (
 		<>
 			<ChatBotLoader styleRootRef={styleRootRef} id={finalBotId} flow={finalFlow} settings={finalSettings}
-				styles={finalStyles} themes={themes} plugins={plugins} setConfigLoaded={setConfigLoaded}
+				styles={finalStyles} themes={themes} plugins={plugins} configLoaded={configLoaded}
+				setConfigLoaded={setConfigLoaded}
 			/>
 			{configLoaded && <ChatBotContainer plugins={plugins} />}
 		</>

--- a/src/components/ChatBotLoader.tsx
+++ b/src/components/ChatBotLoader.tsx
@@ -28,6 +28,7 @@ const ChatBotLoader = ({
 	styles,
 	themes,
 	plugins,
+	configLoaded,
 	setConfigLoaded,
 	styleRootRef,
 }: {
@@ -37,6 +38,7 @@ const ChatBotLoader = ({
 	styles: Styles;
 	themes: Theme | Array<Theme>;
 	plugins: Array<Plugin>;
+	configLoaded: boolean;
 	setConfigLoaded: Dispatch<SetStateAction<boolean>>;
 	styleRootRef: MutableRefObject<HTMLStyleElement | null>;
 }) => {
@@ -95,8 +97,10 @@ const ChatBotLoader = ({
 	}
 
 	useEffect(() => {
-		runLoadConfig();
-	}, [themes]);
+		if(!configLoaded) {
+			runLoadConfig();
+		}
+	}, [configLoaded, themes]);
 
 	return null;
 };


### PR DESCRIPTION
#### Description

Infinite runLoadConifg() call when using ChatBotProvider.

Closes #(issue)

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Use the `configLoaded` state to limit the `runLoadConfig` call to just one instance.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)