### PR TITLE
Test: Add unit test cases for stripHtml in markeupParser

### DIFF
--- a/__tests__/utils/markupParser.test.ts
+++ b/__tests__/utils/markupParser.test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe, beforeEach, jest } from "@jest/globals";
-import { parseMarkupMessage } from "../../src/utils/markupParser";
+import { parseMarkupMessage, stripHtml } from "../../src/utils/markupParser";
 
-describe("", ()=>{
+describe("parseMarkupMessage", ()=>{
     beforeEach(()=>{
         jest.clearAllMocks();
     });
@@ -40,6 +40,47 @@ describe("", ()=>{
 
         expect(message).toEqual(["<div>", " ", "T", "h", "i", "s", " ", "t", "a", "g", " ", "i", "s", " ", "u", "n", "c", "l", "o", "s", "e", "d"] );
     });
-
     
-})
+});
+
+describe("stripHtml", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return the same string when no tags are present", () => {
+        const html = "This is a plain string";
+        const result = stripHtml(html);
+        expect(result).toEqual("This is a plain string");
+    });
+
+    it("should remove a single HTML tag", () => {
+        const html = "<div>This is a plain string</div>";
+        const result = stripHtml(html);
+        expect(result).toEqual("This is a plain string");
+    });
+
+    it("should remove nested HTML tags", () => {
+        const html = "<div>This contains a <strong>bold</strong> word</div>";
+        const result = stripHtml(html);
+        expect(result).toEqual("This contains a bold word");
+    });
+
+    it("should remove multiple tags with attributes", () => {
+        const html = "<a href='http://example.com'>Link</a> to <span style='color: red;'>some text</span>";
+        const result = stripHtml(html);
+        expect(result).toEqual("Link to some text");
+    });
+
+    it("should handle unclosed tags gracefully", () => {
+        const html = "<div>Unclosed tag";
+        const result = stripHtml(html);
+        expect(result).toEqual("Unclosed tag");
+    });
+
+    it("should return an empty string when input is empty", () => {
+        const html = "";
+        const result = stripHtml(html);
+        expect(result).toEqual("");
+    });
+});

--- a/__tests__/utils/markupParser.test.ts
+++ b/__tests__/utils/markupParser.test.ts
@@ -2,85 +2,91 @@ import { expect, it, describe, beforeEach, jest } from "@jest/globals";
 import { parseMarkupMessage, stripHtml } from "../../src/utils/markupParser";
 
 describe("parseMarkupMessage", ()=>{
-    beforeEach(()=>{
-        jest.clearAllMocks();
-    });
+	beforeEach(()=>{
+		jest.clearAllMocks();
+	});
 
-    it("should be able to parse a plain string without tags", ()=>{
-        const result = "This is a plain string";
-        const message = parseMarkupMessage(result);
+	it("should be able to parse a plain string without tags", ()=>{
+		const result = "This is a plain string";
+		const message = parseMarkupMessage(result);
 
-        expect(message).toEqual(["T", "h", "i", "s", " ", "i", "s", " ", "a", " ", "p", "l", "a", "i", "n", " ", "s", "t", "r", "i", "n", "g"]);
-    });
+		expect(message).toEqual(
+			["T", "h", "i", "s", " ", "i", "s", " ", "a", " ", "p", "l", "a", "i", "n", " ", 
+				"s", "t", "r", "i", "n", "g"]
+		);
+	});
 
-    it("should be able to parse a plain string with tags", ()=>{
-        const result = "<div>This is a plain string</div>";
-        const message = parseMarkupMessage(result);
+	it("should be able to parse a plain string with tags", ()=>{
+		const result = "<div>This is a plain string</div>";
+		const message = parseMarkupMessage(result);
 
-        expect(message).toEqual(["<div>", "T", "h", "i", "s", " ", "i", "s", " ", "a", " ", "p", "l", "a", "i", "n", " ", "s", "t", "r", "i", "n", "g", "</div>"]);
-    });
+		expect(message).toEqual(["<div>", "T", "h", "i", "s", " ", "i", "s", " ", "a", " ", "p", 
+			"l", "a", "i", "n", " ", "s", "t", "r", "i", "n", "g", "</div>"]);
+	});
 
-    it("should be able to parse nested tags", ()=>{
-        const result = "<div> This contains a <bold>Bold</bold> tag</div>";
-        const message = parseMarkupMessage(result);
+	it("should be able to parse nested tags", ()=>{
+		const result = "<div> This contains a <bold>Bold</bold> tag</div>";
+		const message = parseMarkupMessage(result);
 
-        expect(message).toEqual(["<div>", " ", "T", "h", "i", "s", " ", "c", "o", "n", "t", "a", "i", "n", "s", " ", "a", " ", "<bold>", "B", "o", "l", "d", "</bold>", " ", "t", "a", "g", "</div>"]);
-    });
+		expect(message).toEqual(["<div>", " ", "T", "h", "i", "s", " ", "c", "o", "n", "t", "a", "i", 
+			"n", "s", " ", "a", " ", "<bold>", "B", "o", "l", "d", "</bold>", " ", "t", "a", "g", "</div>"]);
+	});
 
-    it("should be able to parse attributes in tags", ()=>{
-        const result = "<a href=`http://www.example.com`>Link</a>";
-        const message= parseMarkupMessage(result);
+	it("should be able to parse attributes in tags", ()=>{
+		const result = "<a href=`http://www.example.com`>Link</a>";
+		const message= parseMarkupMessage(result);
 
-        expect(message).toEqual(["<a href=`http://www.example.com`>", "L", "i", "n", "k", "</a>"] );
-    });
+		expect(message).toEqual(["<a href=`http://www.example.com`>", "L", "i", "n", "k", "</a>"] );
+	});
 
-    it("should be able to parse unclosed tags", ()=>{
-        const result = "<div> This tag is unclosed";
-        const message = parseMarkupMessage(result);
+	it("should be able to parse unclosed tags", ()=>{
+		const result = "<div> This tag is unclosed";
+		const message = parseMarkupMessage(result);
 
-        expect(message).toEqual(["<div>", " ", "T", "h", "i", "s", " ", "t", "a", "g", " ", "i", "s", " ", "u", "n", "c", "l", "o", "s", "e", "d"] );
-    });
+		expect(message).toEqual(["<div>", " ", "T", "h", "i", "s", " ", "t", "a", "g", " ", "i", "s", 
+			" ", "u", "n", "c", "l", "o", "s", "e", "d"] );
+	});
     
 });
 
 describe("stripHtml", () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-    it("should return the same string when no tags are present", () => {
-        const html = "This is a plain string";
-        const result = stripHtml(html);
-        expect(result).toEqual("This is a plain string");
-    });
+	it("should return the same string when no tags are present", () => {
+		const html = "This is a plain string";
+		const result = stripHtml(html);
+		expect(result).toEqual("This is a plain string");
+	});
 
-    it("should remove a single HTML tag", () => {
-        const html = "<div>This is a plain string</div>";
-        const result = stripHtml(html);
-        expect(result).toEqual("This is a plain string");
-    });
+	it("should remove a single HTML tag", () => {
+		const html = "<div>This is a plain string</div>";
+		const result = stripHtml(html);
+		expect(result).toEqual("This is a plain string");
+	});
 
-    it("should remove nested HTML tags", () => {
-        const html = "<div>This contains a <strong>bold</strong> word</div>";
-        const result = stripHtml(html);
-        expect(result).toEqual("This contains a bold word");
-    });
+	it("should remove nested HTML tags", () => {
+		const html = "<div>This contains a <strong>bold</strong> word</div>";
+		const result = stripHtml(html);
+		expect(result).toEqual("This contains a bold word");
+	});
 
-    it("should remove multiple tags with attributes", () => {
-        const html = "<a href='http://example.com'>Link</a> to <span style='color: red;'>some text</span>";
-        const result = stripHtml(html);
-        expect(result).toEqual("Link to some text");
-    });
+	it("should remove multiple tags with attributes", () => {
+		const html = "<a href='http://example.com'>Link</a> to <span style='color: red;'>some text</span>";
+		const result = stripHtml(html);
+		expect(result).toEqual("Link to some text");
+	});
 
-    it("should handle unclosed tags gracefully", () => {
-        const html = "<div>Unclosed tag";
-        const result = stripHtml(html);
-        expect(result).toEqual("Unclosed tag");
-    });
+	it("should handle unclosed tags gracefully", () => {
+		const html = "<div>Unclosed tag";
+		const result = stripHtml(html);
+		expect(result).toEqual("Unclosed tag");
+	});
 
-    it("should return an empty string when input is empty", () => {
-        const html = "";
-        const result = stripHtml(html);
-        expect(result).toEqual("");
-    });
+	it("should return an empty string when input is empty", () => {
+		const html = "";
+		const result = stripHtml(html);
+		expect(result).toEqual("");
+	});
 });


### PR DESCRIPTION
#### Description

This pull request extends the unit test cases for the stripHtml function within the markupParser module. The new tests aim to improve test coverage by ensuring that the function handles various scenarios correctly.

Closes #(213)

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

This PR introduces additional unit tests for the stripHtml function within the markupParser module. The approach taken was to create tests that cover a range of common and edge cases, including:
- Input with plain text.
- HTML strings with single and nested tags.
- HTML strings with tags containing attributes.
- Handling of unclosed tags.
- Empty input cases.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)