### PR TITLE
Test: Add unit tests for useSettingsInternal hook

### DIFF
--- a/__tests__/hooks/internal/useSettingsInternal.test.ts
+++ b/__tests__/hooks/internal/useSettingsInternal.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import { useSettingsContext } from "../../../src/context/SettingsContext";
+import { useSettingsInternal } from "../../../src/hooks/internal/useSettingsInternal";
+import { deepClone, getCombinedConfig } from "../../../src/utils/configParser";
+import { act } from "react";
+import { Settings } from "../../../src/types/Settings";
+import { Styles } from "../../../src/types/Styles";
+
+jest.mock("../../../src/context/SettingsContext", () => ({
+    useSettingsContext: jest.fn(),
+}));
+
+jest.mock("../../../src/utils/configParser", () => ({
+    deepClone: jest.fn(),
+    getCombinedConfig: jest.fn(),
+}));
+
+describe("useSettingsInternal", () => {
+    const mockSetSettings = jest.fn();
+    const mockSettings: Settings = { general: { primaryColor: "red" } };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (useSettingsContext as jest.Mock).mockReturnValue({
+            settings: mockSettings,
+            setSettings: mockSetSettings,
+        });
+    });
+
+    it("should return settings, setSettings and updateSettings method", () => {
+        const { result } = renderHook(() => useSettingsInternal());
+
+        expect(result.current.settings).toEqual(mockSettings);
+        expect(result.current.setSettings).toBe(mockSetSettings);
+        expect(result.current.updateSettings).toBeDefined();
+        expect(typeof result.current.updateSettings).toBe("function");
+    });
+
+    it("should update settings using deepClone and getCombinedConfig", () => {
+        const mockUpdatedFields: Settings | Styles = {
+            general: { secondaryColor: "black" },
+        };
+        const mockCombinedConfig: Settings | Styles = {
+            general: { primaryColor: "red", secondaryColor: "black" },
+        };
+
+        (getCombinedConfig as jest.Mock).mockReturnValue(mockCombinedConfig);
+        (deepClone as jest.Mock).mockReturnValue(mockCombinedConfig);
+
+        const { result } = renderHook(() => useSettingsInternal());
+
+        act(() => {
+            result.current.updateSettings(mockUpdatedFields);
+        });
+
+        expect(getCombinedConfig).toHaveBeenCalledWith(
+            mockUpdatedFields,
+            mockSettings
+        );
+        expect(deepClone).toHaveBeenCalledWith(mockCombinedConfig);
+        expect(mockSetSettings).toHaveBeenCalledWith(mockCombinedConfig);
+    });
+
+    it("should handle updateSettings with empty fields", () => {
+        (getCombinedConfig as jest.Mock).mockReturnValue(mockSettings);
+        (deepClone as jest.Mock).mockReturnValue(mockSettings);
+
+        const { result } = renderHook(() => useSettingsInternal());
+
+        act(() => {
+            result.current.updateSettings({});
+        });
+
+        expect(getCombinedConfig).toHaveBeenCalledWith({}, mockSettings);
+        expect(deepClone).toHaveBeenCalledWith(mockSettings);
+        expect(mockSetSettings).toHaveBeenCalledWith(mockSettings);
+    });
+});


### PR DESCRIPTION
#### Description

This PR introduces unit tests for the `useSettingsInternal` hook. These tests cover the hook's behavior, including returning settings, updating settings using helper functions, and handling edge cases like empty fields.

Closes #131 

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

The proposed approach involves writing unit tests for `useSettingsInternal`. The tests use `renderHook` to test the hook's output and behavior, mocking necessary context and utility functions to ensure the correct configuration flow when settings are updated.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)