### PR TITLE
fix: add missing isChatWindowOpen dependency

### DIFF
--- a/__tests__/hooks/internal/useChatWindowInternal.test.ts
+++ b/__tests__/hooks/internal/useChatWindowInternal.test.ts
@@ -51,6 +51,20 @@ describe("useChatWindowInternal Hook", () => {
 
 		// check if chat window state was updated
 		expect(result.current.isChatWindowOpen).toBe(!initialChatWindowOpen);
+
+		// simulates clicking the toggle action
+		await act(async () => {
+			await result.current.toggleChatWindow();
+		});
+
+		// checks if callRcbEvent was called with rcb-toggle-chat-window and correct arguments
+		expect(callRcbEventMock).toHaveBeenCalledWith(RcbEvent.TOGGLE_CHAT_WINDOW, {
+			currState: !initialChatWindowOpen,
+			newState: initialChatWindowOpen,
+		});
+
+		// check if chat window state was updated
+		expect(result.current.isChatWindowOpen).toBe(initialChatWindowOpen);
 	});
 
 	it("should prevent toggling when event is defaultPrevented", async () => {

--- a/src/hooks/internal/useChatWindowInternal.ts
+++ b/src/hooks/internal/useChatWindowInternal.ts
@@ -50,7 +50,7 @@ export const useChatWindowInternal = () => {
 			}
 			return !prev;
 		});
-	}, []);
+	}, [isChatWindowOpen]);
 
 	/**
 	 * Handles opening/closing of the chat window.


### PR DESCRIPTION
#### Description

Event listed [here](https://react-chatbotify.com/docs/api/events#rcbtogglechatwindowevent) has stale vale due to dependency array being empty but it needs to have access to `isChatWindowOpen` to work properly.

Also I've updated the test case so it covers actual toggling of chat window (it is failing  without `isChatWindowOpen` passed as dependency)

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Updating dependency array for `useCallback` hook

#### Checklist:

- [ ] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)