### PR TITLE
ISSUE-282 keep history messages in sync with storage

### DIFF
--- a/__tests__/hooks/internal/useFlowInternal.test.ts
+++ b/__tests__/hooks/internal/useFlowInternal.test.ts
@@ -7,106 +7,118 @@ import { usePathsContext } from "../../../src/context/PathsContext";
 import { useToastsContext } from "../../../src/context/ToastsContext";
 import { useBotStatesContext } from "../../../src/context/BotStatesContext";
 import { useBotRefsContext } from "../../../src/context/BotRefsContext";
+import { useSettingsContext } from "../../../src/context/SettingsContext";
+import { setHistoryStorageValues } from "../../../src/services/ChatHistoryService";
 
 jest.mock("../../../src/context/MessagesContext");
 jest.mock("../../../src/context/PathsContext");
 jest.mock("../../../src/context/ToastsContext");
 jest.mock("../../../src/context/BotStatesContext");
 jest.mock("../../../src/context/BotRefsContext");
+jest.mock("../../../src/context/SettingsContext");
+jest.mock("../../../src/services/ChatHistoryService");
 
 describe("useFlowInternal Hook", () => {
 	const setMessagesMock = jest.fn();
-  const setPathsMock = jest.fn();
+	const setPathsMock = jest.fn();
 	const setToastsMock = jest.fn();
-  const flowRefMock = { current: { id: "test-flow" } };
-  const hasFlowStartedMock = true;
+	const flowRefMock = { current: { id: "test-flow" } };
+	const hasFlowStartedMock = true;
+	const mockSettings = {
+		chatHistory: {
+			storageType: "localStorage",
+			storageKey: "rcb-history",
+		},
+	};
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		(useMessagesContext as jest.Mock).mockReturnValue({ setMessages: setMessagesMock });
+		(usePathsContext as jest.Mock).mockReturnValue({ setPaths: setPathsMock });
+		(useToastsContext as jest.Mock).mockReturnValue({ setToasts: setToastsMock });
+		(useBotRefsContext as jest.Mock).mockReturnValue({ flowRef: flowRefMock });
+		(useBotStatesContext as jest.Mock).mockReturnValue({ hasFlowStarted: hasFlowStartedMock });
+		(useSettingsContext as jest.Mock).mockReturnValue({ settings: mockSettings });
+	});
 
 
-    (useMessagesContext as jest.Mock).mockReturnValue({ setMessages: setMessagesMock });
-    (usePathsContext as jest.Mock).mockReturnValue({ setPaths: setPathsMock });
-    (useToastsContext as jest.Mock).mockReturnValue({ setToasts: setToastsMock });
-    (useBotRefsContext as jest.Mock).mockReturnValue({ flowRef: flowRefMock });
-    (useBotStatesContext as jest.Mock).mockReturnValue({ hasFlowStarted: hasFlowStartedMock });
-  });
+	// Test to ensure initial values (hasFlowStarted and flowRef) are returned correctly from the hook
+	it("should return initial values from context", () => {
+		const { result } = renderHook(() => useFlowInternal());
 
+		expect(result.current.hasFlowStarted).toBe(true);
+		expect(result.current.getFlow()).toEqual({ id: "test-flow" });
+	});
 
-// Test to ensure initial values (hasFlowStarted and flowRef) are returned correctly from the hook
-  it("should return initial values from context", () => {
-    const { result } = renderHook(() => useFlowInternal());
+	// Test to ensure that restartFlow clears messages, toasts, and resets paths
+	it("should restart the flow by clearing messages, toasts, resetting paths and loading history", () => {
+		const { result } = renderHook(() => useFlowInternal());
 
-    expect(result.current.hasFlowStarted).toBe(true);
-    expect(result.current.getFlow()).toEqual({ id: "test-flow" });
-  });
+		act(() => {
+			result.current.restartFlow();
+		});
 
- // Test to ensure that restartFlow clears messages, toasts, and resets paths
-  it("should restart the flow by clearing messages, toasts, and resetting paths", () => {
-    const { result } = renderHook(() => useFlowInternal());
+		expect(setMessagesMock).toHaveBeenCalledWith([]);
+		expect(setToastsMock).toHaveBeenCalledWith([]);
+		expect(setPathsMock).toHaveBeenCalledWith(["start"]);
+		expect(setHistoryStorageValues)
+			.toHaveBeenCalledWith({ chatHistory: { storageType: "localStorage", storageKey: "rcb-history" } });
+	});
 
-    act(() => {
-      result.current.restartFlow();
-    });
+	// Test to ensure that getFlow returns the current flow from flowRef
+	it("should get the current flow from flowRef", () => {
+		const { result } = renderHook(() => useFlowInternal());
 
-    expect(setMessagesMock).toHaveBeenCalledWith([]);
-    expect(setToastsMock).toHaveBeenCalledWith([]);
-    expect(setPathsMock).toHaveBeenCalledWith(["start"]);
-  });
+		const flow = result.current.getFlow();
+		expect(flow).toEqual({ id: "test-flow" });
+	});
 
-// Test to ensure that getFlow returns the current flow from flowRef
-  it("should get the current flow from flowRef", () => {
-    const { result } = renderHook(() => useFlowInternal());
+	// Test to ensure that calling restartFlow multiple times works correctly
+	it("should handle multiple restarts correctly", () => {
+		const { result } = renderHook(() => useFlowInternal());
 
-    const flow = result.current.getFlow();
-    expect(flow).toEqual({ id: "test-flow" });
-  });
+		act(() => {
+			result.current.restartFlow();
+		});
 
-// Test to ensure that calling restartFlow multiple times works correctly
-  it("should handle multiple restarts correctly", () => {
-    const { result } = renderHook(() => useFlowInternal());
+		act(() => {
+			result.current.restartFlow();
+		});
 
-    act(() => {
-      result.current.restartFlow();
-    });
+		expect(setMessagesMock).toHaveBeenCalledTimes(2);
+		expect(setToastsMock).toHaveBeenCalledTimes(2);
+		expect(setPathsMock).toHaveBeenCalledTimes(2);
+	});
 
-    act(() => {
-      result.current.restartFlow();
-    });
+	// Test to check flow state when hasFlowStarted is false
+	it("should correctly reflect flow state when it hasn't started", () => {
+		(useBotStatesContext as jest.Mock).mockReturnValue({ hasFlowStarted: false });
+		const { result } = renderHook(() => useFlowInternal());
 
-    expect(setMessagesMock).toHaveBeenCalledTimes(2);
-    expect(setToastsMock).toHaveBeenCalledTimes(2);
-    expect(setPathsMock).toHaveBeenCalledTimes(2);
-  });
+		expect(result.current.hasFlowStarted).toBe(false);
+	});
 
-// Test to check flow state when hasFlowStarted is false
-  it("should correctly reflect flow state when it hasn't started", () => {
-    (useBotStatesContext as jest.Mock).mockReturnValue({ hasFlowStarted: false });
-    const { result } = renderHook(() => useFlowInternal());
+	// Test to ensure messages, toasts, and paths are initialized correctly when restarting the flow
+	it("should initialize messages, toasts, and paths correctly", () => {
+		const { result } = renderHook(() => useFlowInternal());
 
-    expect(result.current.hasFlowStarted).toBe(false);
-  });
+		act(() => {
+			result.current.restartFlow();
+		});
 
-// Test to ensure messages, toasts, and paths are initialized correctly when restarting the flow
-  it("should initialize messages, toasts, and paths correctly", () => {
-    const { result } = renderHook(() => useFlowInternal());
+		expect(setMessagesMock).toHaveBeenCalledWith([]);
+		expect(setToastsMock).toHaveBeenCalledWith([]);
+		expect(setPathsMock).toHaveBeenCalledWith(["start"]);
+	});
 
-    act(() => {
-      result.current.restartFlow();
-    });
+	// Test to check that getFlow returns different flowRef values correctly
+	it("should handle different flowRef values", () => {
+		const differentFlowRefMock = { current: { id: "different-flow" } };
+		(useBotRefsContext as jest.Mock).mockReturnValue({ flowRef: differentFlowRefMock });
+		const { result } = renderHook(() => useFlowInternal());
 
-    expect(setMessagesMock).toHaveBeenCalledWith([]);
-    expect(setToastsMock).toHaveBeenCalledWith([]);
-    expect(setPathsMock).toHaveBeenCalledWith(["start"]);
-  });
-
-// Test to check that getFlow returns different flowRef values correctly
-  it("should handle different flowRef values", () => {
-    const differentFlowRefMock = { current: { id: "different-flow" } };
-    (useBotRefsContext as jest.Mock).mockReturnValue({ flowRef: differentFlowRefMock });
-    const { result } = renderHook(() => useFlowInternal());
-
-    const flow = result.current.getFlow();
-    expect(flow).toEqual({ id: "different-flow" });
-  });
+		const flow = result.current.getFlow();
+		expect(flow).toEqual({ id: "different-flow" });
+	});
 });

--- a/__tests__/services/ChatHistoryService.test.ts
+++ b/__tests__/services/ChatHistoryService.test.ts
@@ -61,9 +61,6 @@ describe("ChatHistoryService", () => {
 			setHistoryStorageValues(settings);
 			await saveChatHistory([mockMessage]);
 			expect(storage.setItem).not.toHaveBeenCalled();
-
-			const historyMessages = getHistoryMessages();
-			expect(historyMessages).toEqual([]);
 		});
 
 		it("should save history if not disabled", async () => {
@@ -71,20 +68,6 @@ describe("ChatHistoryService", () => {
 			await saveChatHistory([mockMessage]);
 
 			expect(storage.setItem).toHaveBeenCalled();
-
-			const historyMessages = getHistoryMessages();
-			expect(historyMessages).toEqual([mockMessage]);
-		});
-
-		it("should retain previous history if not disabled and empty message array is passed", async () => {
-			setHistoryStorageValues(mockSettings(storageType));
-			await saveChatHistory([mockMessage]);
-			await saveChatHistory([]);
-
-			expect(storage.setItem).toHaveBeenCalledTimes(2);
-
-			const historyMessages = getHistoryMessages();
-			expect(historyMessages).toEqual([mockMessage]);
 		});
 
 		it("should handle empty message array without errors", async () => {

--- a/__tests__/services/ChatHistoryService.test.ts
+++ b/__tests__/services/ChatHistoryService.test.ts
@@ -61,13 +61,30 @@ describe("ChatHistoryService", () => {
 			setHistoryStorageValues(settings);
 			await saveChatHistory([mockMessage]);
 			expect(storage.setItem).not.toHaveBeenCalled();
+
+			const historyMessages = getHistoryMessages();
+			expect(historyMessages).toEqual([]);
 		});
 
 		it("should save history if not disabled", async () => {
 			setHistoryStorageValues(mockSettings(storageType));
 			await saveChatHistory([mockMessage]);
-			
+
 			expect(storage.setItem).toHaveBeenCalled();
+
+			const historyMessages = getHistoryMessages();
+			expect(historyMessages).toEqual([mockMessage]);
+		});
+
+		it("should retain previous history if not disabled and empty message array is passed", async () => {
+			setHistoryStorageValues(mockSettings(storageType));
+			await saveChatHistory([mockMessage]);
+			await saveChatHistory([]);
+
+			expect(storage.setItem).toHaveBeenCalledTimes(2);
+
+			const historyMessages = getHistoryMessages();
+			expect(historyMessages).toEqual([mockMessage]);
 		});
 
 		it("should handle empty message array without errors", async () => {

--- a/src/hooks/internal/useFlowInternal.ts
+++ b/src/hooks/internal/useFlowInternal.ts
@@ -1,17 +1,19 @@
-import { useCallback } from "react";
+import {useCallback} from "react";
 
-import { useMessagesInternal } from "./useMessagesInternal";
-import { usePathsInternal } from "./usePathsInternal";
-import { useToastsInternal } from "./useToastsInternal";
-import { useBotRefsContext } from "../../context/BotRefsContext";
-import { useBotStatesContext } from "../../context/BotStatesContext";
+import {useMessagesInternal} from "./useMessagesInternal";
+import {usePathsInternal} from "./usePathsInternal";
+import {useToastsInternal} from "./useToastsInternal";
+import {useBotRefsContext} from "../../context/BotRefsContext";
+import {useBotStatesContext} from "../../context/BotStatesContext";
+import {setHistoryStorageValues} from "../../services/ChatHistoryService";
+import {useSettingsContext} from "../../context/SettingsContext";
 
 /**
  * Internal custom hook for managing flow.
  */
 export const useFlowInternal = () => {
 	// handles messages
-	const { replaceMessages } = useMessagesInternal();
+	const { replaceMessages, messages } = useMessagesInternal();
 	
 	// handles paths
 	const { replacePaths } = usePathsInternal();
@@ -24,6 +26,9 @@ export const useFlowInternal = () => {
 	
 	// handles bot refs
 	const { flowRef } = useBotRefsContext();
+
+	// handles bot settings
+	const { settings } = useSettingsContext();
 	
 	/**
 	 * Restarts the conversation flow for the chatbot.
@@ -32,7 +37,12 @@ export const useFlowInternal = () => {
 		replaceMessages([]);
 		replaceToasts([]);
 		replacePaths(["start"]);
-	}, [replaceMessages, replaceToasts, replacePaths]);
+
+		//reload the chat history from storage
+		setHistoryStorageValues(settings)
+		console.log("Flow restarted");
+		console.log("Messages", messages);
+	}, [replaceMessages, replaceToasts, replacePaths, setHistoryStorageValues]);
 	
 	/**
 	 * Retrieves the conversation flow for the chatbot.

--- a/src/hooks/internal/useFlowInternal.ts
+++ b/src/hooks/internal/useFlowInternal.ts
@@ -34,12 +34,12 @@ export const useFlowInternal = () => {
 	 * Restarts the conversation flow for the chatbot.
 	 */
 	const restartFlow = useCallback(() => {
+		//reload the chat history from storage
+		setHistoryStorageValues(settings)
+
 		replaceMessages([]);
 		replaceToasts([]);
 		replacePaths(["start"]);
-
-		//reload the chat history from storage
-		setHistoryStorageValues(settings)
 	}, [replaceMessages, replaceToasts, replacePaths, setHistoryStorageValues]);
 	
 	/**

--- a/src/hooks/internal/useFlowInternal.ts
+++ b/src/hooks/internal/useFlowInternal.ts
@@ -13,7 +13,7 @@ import {useSettingsContext} from "../../context/SettingsContext";
  */
 export const useFlowInternal = () => {
 	// handles messages
-	const { replaceMessages, messages } = useMessagesInternal();
+	const { replaceMessages } = useMessagesInternal();
 	
 	// handles paths
 	const { replacePaths } = usePathsInternal();
@@ -40,8 +40,6 @@ export const useFlowInternal = () => {
 
 		//reload the chat history from storage
 		setHistoryStorageValues(settings)
-		console.log("Flow restarted");
-		console.log("Messages", messages);
 	}, [replaceMessages, replaceToasts, replacePaths, setHistoryStorageValues]);
 	
 	/**

--- a/src/hooks/internal/useMessagesInternal.ts
+++ b/src/hooks/internal/useMessagesInternal.ts
@@ -323,7 +323,7 @@ export const useMessagesInternal = () => {
 			// defer update to next event loop, handles edge case where messages are sent too fast
 			// and the scrolling does not properly reach the bottom
 			setTimeout(() => {
-				if (!chatBodyRef.current) {
+				if (!chatBodyRef?.current) {
 					return;
 				}
 

--- a/src/services/ChatHistoryService.tsx
+++ b/src/services/ChatHistoryService.tsx
@@ -51,6 +51,7 @@ const saveChatHistory = async (messages: Message[]) => {
 		parsedMessages = [...historyMessages.slice(-difference), ...parsedMessages]
 	}
 
+	historyMessages = parsedMessages;
 	setHistoryMessages(parsedMessages);
 }
 

--- a/src/services/ChatHistoryService.tsx
+++ b/src/services/ChatHistoryService.tsx
@@ -51,7 +51,6 @@ const saveChatHistory = async (messages: Message[]) => {
 		parsedMessages = [...historyMessages.slice(-difference), ...parsedMessages]
 	}
 
-	historyMessages = parsedMessages;
 	setHistoryMessages(parsedMessages);
 }
 


### PR DESCRIPTION
#### Description

Changed saveChatHistory by assigning the latest state to ChatHistoryService it's historyMessages.

Closes https://github.com/tjtanjin/react-chatbotify/issues/282

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

- Fix the bug
-Change / Add tests

#### Checklist:

- [ ] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)