### PR TITLE
Added unFocusTextArea to manage text area blur functionality

### DIFF
--- a/__tests__/hooks/internal/useTextAreaInternal.test.ts
+++ b/__tests__/hooks/internal/useTextAreaInternal.test.ts
@@ -158,6 +158,21 @@ describe("useTextAreaInternal Hook", () => {
     expect(result.current.textAreaDisabled).toBe(false);
   });
 
+  it("should unfocus on text area when unFocusTextArea is called", () => {
+    const callRcbEventMock = jest.fn();
+    mockUseRcbEventInternal.mockReturnValue({
+      callRcbEvent: callRcbEventMock,
+    });
+
+    const { result } = renderHook(() => useTextAreaInternal());
+
+    act(() => {
+      result.current.unFocusTextArea();
+    });
+
+    expect(mockInputRef.current.blur).toHaveBeenCalled();
+  });
+
  // let initialTextAreaDisabled = false;
 
  /* it("should toggle textAreaDisabled state", () => {

--- a/__tests__/hooks/internal/useTextAreaInternal.test.ts
+++ b/__tests__/hooks/internal/useTextAreaInternal.test.ts
@@ -158,7 +158,7 @@ describe("useTextAreaInternal Hook", () => {
     expect(result.current.textAreaDisabled).toBe(false);
   });
 
-  it("should unfocus on text area when unFocusTextArea is called", () => {
+  it("should blur on text area when blurTextArea is called", () => {
     const callRcbEventMock = jest.fn();
     mockUseRcbEventInternal.mockReturnValue({
       callRcbEvent: callRcbEventMock,
@@ -167,7 +167,7 @@ describe("useTextAreaInternal Hook", () => {
     const { result } = renderHook(() => useTextAreaInternal());
 
     act(() => {
-      result.current.unFocusTextArea();
+      result.current.blurTextArea();
     });
 
     expect(mockInputRef.current.blur).toHaveBeenCalled();

--- a/src/hooks/internal/useTextAreaInternal.ts
+++ b/src/hooks/internal/useTextAreaInternal.ts
@@ -105,7 +105,16 @@ export const useTextAreaInternal = () => {
 	}, [textAreaDisabled]);
 
 	/**
-	 * Retrieves text area value.
+	 * Focuses on text area.
+	 */
+		const unFocusTextArea = useCallback(() => {
+			if (inputRef.current) {
+				inputRef.current.blur();
+			}
+		}, []);
+	/**
+	
+	* Retrieves text area value.
 	 */
 	const getTextAreaValue = useCallback(() => {
 		if (inputRef && inputRef.current) {

--- a/src/hooks/internal/useTextAreaInternal.ts
+++ b/src/hooks/internal/useTextAreaInternal.ts
@@ -105,9 +105,9 @@ export const useTextAreaInternal = () => {
 	}, [textAreaDisabled]);
 
 	/**
-	 * Focuses on text area.
+	 * Blurs on text area.
 	 */
-		const unFocusTextArea = useCallback(() => {
+		const blurTextArea = useCallback(() => {
 			if (inputRef.current) {
 				inputRef.current.blur();
 			}
@@ -149,6 +149,7 @@ export const useTextAreaInternal = () => {
 		setTextAreaValue,
 		updateTextAreaFocus,
 		focusTextArea,
+		blurTextArea,
 		toggleTextAreaDisabled,
 		toggleTextAreaSensitiveMode
 	};

--- a/src/hooks/useTextArea.ts
+++ b/src/hooks/useTextArea.ts
@@ -17,7 +17,8 @@ export const useTextArea = () => {
 		toggleTextAreaSensitiveMode,
 		getTextAreaValue,
 		setTextAreaValue,
-		focusTextArea
+		focusTextArea,
+		unFocusTextArea
 	} = useTextAreaInternal();
 
 	return {
@@ -27,6 +28,7 @@ export const useTextArea = () => {
 		toggleTextAreaSensitiveMode,
 		getTextAreaValue,
 		setTextAreaValue,
-		focusTextArea
+		focusTextArea,
+		unFocusTextArea
 	};
 };

--- a/src/hooks/useTextArea.ts
+++ b/src/hooks/useTextArea.ts
@@ -18,7 +18,7 @@ export const useTextArea = () => {
 		getTextAreaValue,
 		setTextAreaValue,
 		focusTextArea,
-		unFocusTextArea
+		blurTextArea
 	} = useTextAreaInternal();
 
 	return {
@@ -29,6 +29,6 @@ export const useTextArea = () => {
 		getTextAreaValue,
 		setTextAreaValue,
 		focusTextArea,
-		unFocusTextArea
+		blurTextArea
 	};
 };


### PR DESCRIPTION
#### Description

This PR introduces the `unFocusTextArea` functionality in the `useTextAreaInternal` hook, which allows programmatic removal of focus from the text area. This complements the existing `focusTextArea` method and provides additional control over the text area's behavior.
Closes #(issue)

#### What change does this PR introduce?

Please select the relevant option(s).
NA

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

The unFocusTextArea method was added as a useCallback function within the useTextAreaInternal hook. It leverages the blur method on the inputRef to remove focus from the text area. Additionally, a new test case was created to verify this behavior, ensuring it works as intended without impacting existing functionality.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)