### PR TITLE
fix(chat-history): rebuild snapshot on save to remove ghost messages;…

### DIFF
--- a/__tests__/services/ChatHistoryRemoval.test.ts
+++ b/__tests__/services/ChatHistoryRemoval.test.ts
@@ -1,89 +1,89 @@
 import {
-  saveChatHistory,
-  setHistoryMessages,
-  setHistoryStorageValues,
+	saveChatHistory,
+	setHistoryMessages,
+	setHistoryStorageValues,
 } from "../../src/services/ChatHistoryService";
 import { Message } from "../../src/types/Message";
 
 // Simple mock settings fulfilling only required chatHistory shape
 const baseSettings: any = {
-  chatHistory: {
-    storageKey: "rcb-history-test",
-    maxEntries: 30,
-    disabled: false,
-    storageType: "LOCAL_STORAGE",
-  },
+	chatHistory: {
+		storageKey: "rcb-history-test",
+		maxEntries: 30,
+		disabled: false,
+		storageType: "LOCAL_STORAGE",
+	},
 };
 
 describe("ChatHistoryService removal persistence", () => {
-  beforeEach(() => {
-    // jsdom localStorage clear
-    localStorage.clear();
-    // initialize storage values
-    setHistoryStorageValues(baseSettings);
-    setHistoryMessages([] as Message[]);
-  });
+	beforeEach(() => {
+		// jsdom localStorage clear
+		localStorage.clear();
+		// initialize storage values
+		setHistoryStorageValues(baseSettings);
+		setHistoryMessages([] as Message[]);
+	});
 
-  const factory = (
-    id: string,
-    content: string,
-    sender: string = "BOT"
-  ): Message => ({
-    id,
-    content,
-    sender,
-    type: "string",
-    timestamp: new Date().toUTCString(),
-    tags: [],
-  });
+	const factory = (
+		id: string,
+		content: string,
+		sender: string = "BOT"
+	): Message => ({
+		id,
+		content,
+		sender,
+		type: "string",
+		timestamp: new Date().toUTCString(),
+		tags: [],
+	});
 
-  it("removes deleted messages from persisted history", async () => {
-    const messages: Message[] = [
-      factory("1", "Hello"),
-      factory("2", "World"),
-      factory("3", "!"),
-    ];
+	it("removes deleted messages from persisted history", async () => {
+		const messages: Message[] = [
+			factory("1", "Hello"),
+			factory("2", "World"),
+			factory("3", "!"),
+		];
 
-    await saveChatHistory(messages);
-    expect(
-      JSON.parse(localStorage.getItem("rcb-history-test") as string).length
-    ).toBe(3);
+		await saveChatHistory(messages);
+		expect(
+			JSON.parse(localStorage.getItem("rcb-history-test") as string).length
+		).toBe(3);
 
-    // simulate removal of message with id 2
-    const afterRemoval = messages.filter((m) => m.id !== "2");
-    await saveChatHistory(afterRemoval);
+		// simulate removal of message with id 2
+		const afterRemoval = messages.filter((m) => m.id !== "2");
+		await saveChatHistory(afterRemoval);
 
-    const stored = JSON.parse(
+		const stored = JSON.parse(
       localStorage.getItem("rcb-history-test") as string
-    ) as Message[];
-    expect(stored.map((m) => m.id)).toEqual(["1", "3"]);
-  });
+		) as Message[];
+		expect(stored.map((m) => m.id)).toEqual(["1", "3"]);
+	});
 
-  it(
-    "does not reintroduce previously removed message when a new message with " +
+	it(
+		"does not reintroduce previously removed message when a new message with " +
       "same rendered HTML is added",
-    async () => {
-      const first = factory("1", "<b>Typing...</b>");
-      await saveChatHistory([first]);
-      let stored = JSON.parse(
+		async () => {
+			const first = factory("1", "<b>Typing...</b>");
+			await saveChatHistory([first]);
+			let stored = JSON.parse(
         localStorage.getItem("rcb-history-test") as string
-      ) as Message[];
-      expect(stored.length).toBe(1);
+			) as Message[];
+			expect(stored.length).toBe(1);
 
-      // remove message 1 (empty array)
-      await saveChatHistory([]);
-      stored = JSON.parse(
+			// remove message 1 (empty array)
+			await saveChatHistory([]);
+			stored = JSON.parse(
         localStorage.getItem("rcb-history-test") as string
-      ) as Message[];
-      expect(stored.length).toBe(0);
+			) as Message[];
+			expect(stored.length).toBe(0);
 
-      // inject a NEW message with same HTML but different id
-      const second = factory("2", "<b>Typing...</b>");
-      await saveChatHistory([second]);
-      stored = JSON.parse(
+			// inject a NEW message with same HTML but different id
+			const second = factory("2", "<b>Typing...</b>");
+			await saveChatHistory([second]);
+			stored = JSON.parse(
         localStorage.getItem("rcb-history-test") as string
-      ) as Message[];
-      expect(stored.map((m) => m.id)).toEqual(["2"]);
-    }
-  );
+			) as Message[];
+			expect(stored.map((m) => m.id)).toEqual(["2"]);
+		}
+	);
 });

--- a/src/services/ChatHistoryService.tsx
+++ b/src/services/ChatHistoryService.tsx
@@ -1,10 +1,10 @@
 import {
-  createElement,
-  isValidElement,
-  Dispatch,
-  ReactNode,
-  CSSProperties,
-  SetStateAction,
+	createElement,
+	isValidElement,
+	Dispatch,
+	ReactNode,
+	CSSProperties,
+	SetStateAction,
 } from "react";
 import ReactDOMServer from "react-dom/server";
 
@@ -30,33 +30,33 @@ let historyMessages: Message[] = [];
  * @param messages messages containing current conversation with the bot
  */
 const saveChatHistory = async (messages: Message[]) => {
-  if (historyDisabled || !storage) {
-    return;
-  }
+	if (historyDisabled || !storage) {
+		return;
+	}
 
-  // Rebuild the persisted history snapshot from the latest messages every call (bounded by historyMaxEntries)
-  // instead of attempting incremental appends. This guarantees that removals, edits, or re-ordering
-  // are faithfully reflected in storage and prevents "ghost" messages from reappearing on reload.
-  const snapshot: Message[] = [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (snapshot.length === historyMaxEntries) {
-      break;
-    }
-    const message = messages[i];
-    // Exclude system messages & empty content (mirrors original intent)
-    if (message.sender.toUpperCase() === "SYSTEM") {
-      continue;
-    }
-    if (message.content === "") {
-      continue;
-    }
-    snapshot.unshift(message);
-  }
+	// Rebuild the persisted history snapshot from the latest messages every call (bounded by historyMaxEntries)
+	// instead of attempting incremental appends. This guarantees that removals, edits, or re-ordering
+	// are faithfully reflected in storage and prevents "ghost" messages from reappearing on reload.
+	const snapshot: Message[] = [];
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (snapshot.length === historyMaxEntries) {
+			break;
+		}
+		const message = messages[i];
+		// Exclude system messages & empty content (mirrors original intent)
+		if (message.sender.toUpperCase() === "SYSTEM") {
+			continue;
+		}
+		if (message.content === "") {
+			continue;
+		}
+		snapshot.unshift(message);
+	}
 
-  const parsedMessages: Message[] = snapshot.map(parseMessageToString);
-  updateHistoryMessages(parsedMessages);
-  // keep in-memory reference in sync so future operations (e.g. load without reload) see updated set
-  historyMessages = parsedMessages;
+	const parsedMessages: Message[] = snapshot.map(parseMessageToString);
+	updateHistoryMessages(parsedMessages);
+	// keep in-memory reference in sync so future operations (e.g. load without reload) see updated set
+	historyMessages = parsedMessages;
 };
 
 /**
@@ -65,21 +65,21 @@ const saveChatHistory = async (messages: Message[]) => {
  * @param historyStorageKey key used to identify chat history stored in local storage
  */
 const parseHistoryMessages = (historyStorageKey: string) => {
-  if (historyStorageKey != null) {
-    try {
-      return JSON.parse(historyStorageKey);
-    } catch {
-      return [];
-    }
-  }
-  return [];
+	if (historyStorageKey != null) {
+		try {
+			return JSON.parse(historyStorageKey);
+		} catch {
+			return [];
+		}
+	}
+	return [];
 };
 
 /**
  * Retrieves history messages.
  */
 const getHistoryMessages = () => {
-  return historyMessages;
+	return historyMessages;
 };
 
 /**
@@ -88,8 +88,8 @@ const getHistoryMessages = () => {
  * @param messages chat history messages to set
  */
 const setHistoryMessages = (messages: Message[]) => {
-  updateHistoryMessages(messages);
-  historyMessages = messages;
+	updateHistoryMessages(messages);
+	historyMessages = messages;
 };
 
 /**
@@ -98,20 +98,20 @@ const setHistoryMessages = (messages: Message[]) => {
  * @param messages chat history messages to update
  */
 const updateHistoryMessages = (messages: Message[]) => {
-  if (!storage) {
-    return;
-  }
-  storage.setItem(historyStorageKey, JSON.stringify(messages));
+	if (!storage) {
+		return;
+	}
+	storage.setItem(historyStorageKey, JSON.stringify(messages));
 };
 
 /**
  * Clears existing history messages.
  */
 const clearHistoryMessages = () => {
-  if (!storage) {
-    return;
-  }
-  storage.removeItem(historyStorageKey);
+	if (!storage) {
+		return;
+	}
+	storage.removeItem(historyStorageKey);
 };
 
 /**
@@ -120,17 +120,17 @@ const clearHistoryMessages = () => {
  * @param settings options provided to the bot
  */
 const setHistoryStorageValues = (settings: Settings) => {
-  if (settings.chatHistory?.storageType?.toUpperCase() === "SESSION_STORAGE") {
-    storage = sessionStorage;
-  } else {
-    storage = localStorage;
-  }
-  historyStorageKey = settings.chatHistory?.storageKey as string;
-  historyMaxEntries = settings.chatHistory?.maxEntries as number;
-  historyDisabled = settings.chatHistory?.disabled as boolean;
-  historyMessages = parseHistoryMessages(
+	if (settings.chatHistory?.storageType?.toUpperCase() === "SESSION_STORAGE") {
+		storage = sessionStorage;
+	} else {
+		storage = localStorage;
+	}
+	historyStorageKey = settings.chatHistory?.storageKey as string;
+	historyMaxEntries = settings.chatHistory?.maxEntries as number;
+	historyDisabled = settings.chatHistory?.disabled as boolean;
+	historyMessages = parseHistoryMessages(
     storage.getItem(historyStorageKey) as string
-  );
+	);
 };
 
 /**
@@ -139,19 +139,19 @@ const setHistoryStorageValues = (settings: Settings) => {
  * @param message message to parse
  */
 const parseMessageToString = (message: Message) => {
-  if (isValidElement(message.content)) {
-    const clonedMessage = structuredClone({
-      id: message.id,
-      content: ReactDOMServer.renderToString(message.content),
-      type: message.type,
-      sender: message.sender.toUpperCase(),
-      timestamp: message.timestamp,
-      tags: message.tags,
-    });
-    return clonedMessage;
-  }
+	if (isValidElement(message.content)) {
+		const clonedMessage = structuredClone({
+			id: message.id,
+			content: ReactDOMServer.renderToString(message.content),
+			type: message.type,
+			sender: message.sender.toUpperCase(),
+			timestamp: message.timestamp,
+			tags: message.tags,
+		});
+		return clonedMessage;
+	}
 
-  return message;
+	return message;
 };
 
 /**
@@ -168,62 +168,62 @@ const parseMessageToString = (message: Message) => {
  * @param setHasChatHistoryLoaded setter for indicating if chat history is loaded
  */
 const loadChatHistory = (
-  settings: Settings,
-  styles: Styles,
-  chatHistory: Message[],
-  setSyncedMessages: Dispatch<SetStateAction<Message[]>>,
-  syncedMessagesRef: React.MutableRefObject<Message[]>,
-  chatBodyRef: React.RefObject<HTMLDivElement | null>,
-  chatScrollHeight: number,
-  setIsLoadingChatHistory: Dispatch<boolean>,
-  setHasChatHistoryLoaded: Dispatch<boolean>
+	settings: Settings,
+	styles: Styles,
+	chatHistory: Message[],
+	setSyncedMessages: Dispatch<SetStateAction<Message[]>>,
+	syncedMessagesRef: React.MutableRefObject<Message[]>,
+	chatBodyRef: React.RefObject<HTMLDivElement | null>,
+	chatScrollHeight: number,
+	setIsLoadingChatHistory: Dispatch<boolean>,
+	setHasChatHistoryLoaded: Dispatch<boolean>
 ) => {
-  // (historyLoaded flag removed in snapshot-based persistence)
-  if (chatHistory != null) {
-    try {
-      // insert loader
-      const loaderMessage = createMessage(<LoadingSpinner />, "SYSTEM");
-      const base = syncedMessagesRef.current.slice(1);
-      setSyncedMessages([loaderMessage, ...base]);
+	// (historyLoaded flag removed in snapshot-based persistence)
+	if (chatHistory != null) {
+		try {
+			// insert loader
+			const loaderMessage = createMessage(<LoadingSpinner />, "SYSTEM");
+			const base = syncedMessagesRef.current.slice(1);
+			setSyncedMessages([loaderMessage, ...base]);
 
-      const parsedMessages = chatHistory.map((message) => {
-        if (message.type === "object") {
-          const element = renderHTML(
+			const parsedMessages = chatHistory.map((message) => {
+				if (message.type === "object") {
+					const element = renderHTML(
             message.content as string,
             settings,
             styles
-          );
-          return { ...message, content: element };
-        }
-        return message;
-      }) as Message[];
+					);
+					return { ...message, content: element };
+				}
+				return message;
+			}) as Message[];
 
-      setTimeout(() => {
-        const rest = syncedMessagesRef.current.slice(1);
+			setTimeout(() => {
+				const rest = syncedMessagesRef.current.slice(1);
 
-        // if autoload, line break is invisible
-        let lineBreakMessage = settings.chatHistory?.autoLoad
-          ? createMessage(<></>, "SYSTEM")
-          : createMessage(<ChatHistoryLineBreak />, "SYSTEM");
-        setSyncedMessages([...parsedMessages, lineBreakMessage, ...rest]);
-        setHasChatHistoryLoaded(true);
-      }, 500);
+				// if autoload, line break is invisible
+				let lineBreakMessage = settings.chatHistory?.autoLoad
+					? createMessage(<></>, "SYSTEM")
+					: createMessage(<ChatHistoryLineBreak />, "SYSTEM");
+				setSyncedMessages([...parsedMessages, lineBreakMessage, ...rest]);
+				setHasChatHistoryLoaded(true);
+			}, 500);
 
-      // slight delay afterwards to maintain scroll position
-      setTimeout(() => {
-        if (!chatBodyRef.current) {
-          return;
-        }
-        const { scrollHeight } = chatBodyRef.current;
-        const diff = scrollHeight - chatScrollHeight;
-        chatBodyRef.current.scrollTop += diff;
-        setIsLoadingChatHistory(false);
-      }, 510);
-    } catch {
-      // remove chat history on error (to address corrupted storage values)
-      storage.removeItem(settings.chatHistory?.storageKey as string);
-    }
-  }
+			// slight delay afterwards to maintain scroll position
+			setTimeout(() => {
+				if (!chatBodyRef.current) {
+					return;
+				}
+				const { scrollHeight } = chatBodyRef.current;
+				const diff = scrollHeight - chatScrollHeight;
+				chatBodyRef.current.scrollTop += diff;
+				setIsLoadingChatHistory(false);
+			}, 510);
+		} catch {
+			// remove chat history on error (to address corrupted storage values)
+			storage.removeItem(settings.chatHistory?.storageKey as string);
+		}
+	}
 };
 
 /**
@@ -233,115 +233,115 @@ const loadChatHistory = (
  * @param settings options provided to the bot
  */
 const renderHTML = (
-  html: string,
-  settings: Settings,
-  styles: Styles
+	html: string,
+	settings: Settings,
+	styles: Styles
 ): ReactNode[] => {
-  const parser = new DOMParser();
-  const parsedHtml = parser.parseFromString(html, "text/html");
-  const nodes = Array.from(parsedHtml.body.childNodes);
+	const parser = new DOMParser();
+	const parsedHtml = parser.parseFromString(html, "text/html");
+	const nodes = Array.from(parsedHtml.body.childNodes);
 
-  const renderNodes: ReactNode[] = nodes.map((node, index) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      return node.textContent;
-    } else {
-      const tagName = (node as Element).tagName.toLowerCase();
-      let attributes = Array.from((node as Element).attributes).reduce(
-        (acc, attr) => {
-          const attributeName = attr.name.toLowerCase();
-          if (attributeName === "style") {
-            const styleProperties = attr.value
-              .split(";")
-              .filter((property) => property.trim() !== "");
-            const styleObject: { [key: string]: string } = {};
-            styleProperties.forEach((property) => {
-              const [key, value] = property
-                .split(":")
-                .map((part) => part.trim());
-              const reactCompliantKey = key.replace(
-                /-([a-z])/g,
-                (match, letter) => letter.toUpperCase()
-              );
-              styleObject[reactCompliantKey] = value;
-            });
-            acc[attributeName] = styleObject;
-          } else if (
-            (tagName === "audio" || tagName === "video") &&
+	const renderNodes: ReactNode[] = nodes.map((node, index) => {
+		if (node.nodeType === Node.TEXT_NODE) {
+			return node.textContent;
+		} else {
+			const tagName = (node as Element).tagName.toLowerCase();
+			let attributes = Array.from((node as Element).attributes).reduce(
+				(acc, attr) => {
+					const attributeName = attr.name.toLowerCase();
+					if (attributeName === "style") {
+						const styleProperties = attr.value
+							.split(";")
+							.filter((property) => property.trim() !== "");
+						const styleObject: { [key: string]: string } = {};
+						styleProperties.forEach((property) => {
+							const [key, value] = property
+								.split(":")
+								.map((part) => part.trim());
+							const reactCompliantKey = key.replace(
+								/-([a-z])/g,
+								(match, letter) => letter.toUpperCase()
+							);
+							styleObject[reactCompliantKey] = value;
+						});
+						acc[attributeName] = styleObject;
+					} else if (
+						(tagName === "audio" || tagName === "video") &&
             attributeName === "controls" &&
             attr.value === ""
-          ) {
-            acc[attributeName] = "true";
-          } else {
-            acc[attributeName] = attr.value;
-          }
-          return acc;
-        },
+					) {
+						acc[attributeName] = "true";
+					} else {
+						acc[attributeName] = attr.value;
+					}
+					return acc;
+				},
         {} as { [key: string]: string | CSSProperties }
-      );
+			);
 
-      // if have class property, repopulate styles and rename to className instead
-      if (Object.prototype.hasOwnProperty.call(attributes, "class")) {
-        const classList = (node as Element).classList;
-        attributes["className"] = classList.toString();
-        delete attributes["class"];
-        if (settings.botBubble?.showAvatar) {
-          attributes = addStyleToContainers(classList, attributes);
-        }
-        attributes = addStyleToOptions(classList, attributes, settings, styles);
-        attributes = addStyleToCheckboxRows(
-          classList,
-          attributes,
-          settings,
-          styles
-        );
-        attributes = addStyleToCheckboxNextButton(
-          classList,
-          attributes,
-          settings,
-          styles
-        );
-        attributes = addStyleToMediaDisplayContainer(
-          classList,
-          attributes,
-          settings,
-          styles
-        );
-      }
+			// if have class property, repopulate styles and rename to className instead
+			if (Object.prototype.hasOwnProperty.call(attributes, "class")) {
+				const classList = (node as Element).classList;
+				attributes["className"] = classList.toString();
+				delete attributes["class"];
+				if (settings.botBubble?.showAvatar) {
+					attributes = addStyleToContainers(classList, attributes);
+				}
+				attributes = addStyleToOptions(classList, attributes, settings, styles);
+				attributes = addStyleToCheckboxRows(
+					classList,
+					attributes,
+					settings,
+					styles
+				);
+				attributes = addStyleToCheckboxNextButton(
+					classList,
+					attributes,
+					settings,
+					styles
+				);
+				attributes = addStyleToMediaDisplayContainer(
+					classList,
+					attributes,
+					settings,
+					styles
+				);
+			}
 
-      const voidElements = [
-        "area",
-        "base",
-        "br",
-        "col",
-        "embed",
-        "hr",
-        "img",
-        "input",
-        "link",
-        "meta",
-        "source",
-        "track",
-        "wbr",
-      ];
-      if (voidElements.includes(tagName)) {
-        // void elements must not have children
-        return createElement(tagName, { key: index, ...attributes });
-      } else {
-        const children = renderHTML(
-          (node as Element).innerHTML,
-          settings,
-          styles
-        );
-        return createElement(
-          tagName,
-          { key: index, ...attributes },
-          ...children
-        );
-      }
-    }
-  });
+			const voidElements = [
+				"area",
+				"base",
+				"br",
+				"col",
+				"embed",
+				"hr",
+				"img",
+				"input",
+				"link",
+				"meta",
+				"source",
+				"track",
+				"wbr",
+			];
+			if (voidElements.includes(tagName)) {
+				// void elements must not have children
+				return createElement(tagName, { key: index, ...attributes });
+			} else {
+				const children = renderHTML(
+					(node as Element).innerHTML,
+					settings,
+					styles
+				);
+				return createElement(
+					tagName,
+					{ key: index, ...attributes },
+					...children
+				);
+			}
+		}
+	});
 
-  return renderNodes;
+	return renderNodes;
 };
 
 /**
@@ -351,16 +351,16 @@ const renderHTML = (
  * @param attributes current attributes the element has
  */
 const addStyleToContainers = (
-  classList: DOMTokenList,
-  attributes: { [key: string]: string | CSSProperties }
+	classList: DOMTokenList,
+	attributes: { [key: string]: string | CSSProperties }
 ) => {
-  if (
-    classList.contains("rcb-options-container") ||
+	if (
+		classList.contains("rcb-options-container") ||
     classList.contains("rcb-checkbox-container")
-  ) {
-    attributes["className"] = `${classList.toString()} rcb-options-offset`;
-  }
-  return attributes;
+	) {
+		attributes["className"] = `${classList.toString()} rcb-options-offset`;
+	}
+	return attributes;
 };
 
 /**
@@ -371,22 +371,22 @@ const addStyleToContainers = (
  * @param settings options provided to the bot
  */
 const addStyleToOptions = (
-  classList: DOMTokenList,
-  attributes: { [key: string]: string | CSSProperties },
-  settings: Settings,
-  styles: Styles
+	classList: DOMTokenList,
+	attributes: { [key: string]: string | CSSProperties },
+	settings: Settings,
+	styles: Styles
 ) => {
-  if (classList.contains("rcb-options")) {
-    attributes["style"] = {
-      ...(attributes["style"] as CSSProperties),
-      color: styles.botOptionStyle?.color ?? settings.general?.primaryColor,
-      borderColor:
+	if (classList.contains("rcb-options")) {
+		attributes["style"] = {
+			...(attributes["style"] as CSSProperties),
+			color: styles.botOptionStyle?.color ?? settings.general?.primaryColor,
+			borderColor:
         styles.botOptionStyle?.color ?? settings.general?.primaryColor,
-      cursor: `url("${settings.general?.actionDisabledIcon}"), auto`,
-      ...styles.botOptionStyle,
-    };
-  }
-  return attributes;
+			cursor: `url("${settings.general?.actionDisabledIcon}"), auto`,
+			...styles.botOptionStyle,
+		};
+	}
+	return attributes;
 };
 
 /**
@@ -397,23 +397,23 @@ const addStyleToOptions = (
  * @param settings options provided to the bot
  */
 const addStyleToCheckboxRows = (
-  classList: DOMTokenList,
-  attributes: { [key: string]: string | CSSProperties },
-  settings: Settings,
-  styles: Styles
+	classList: DOMTokenList,
+	attributes: { [key: string]: string | CSSProperties },
+	settings: Settings,
+	styles: Styles
 ) => {
-  if (classList.contains("rcb-checkbox-row-container")) {
-    attributes["style"] = {
-      ...(attributes["style"] as CSSProperties),
-      color:
+	if (classList.contains("rcb-checkbox-row-container")) {
+		attributes["style"] = {
+			...(attributes["style"] as CSSProperties),
+			color:
         styles.botCheckboxRowStyle?.color ?? settings.general?.primaryColor,
-      borderColor:
+			borderColor:
         styles.botCheckboxRowStyle?.color ?? settings.general?.primaryColor,
-      cursor: `url("${settings.general?.actionDisabledIcon}"), auto`,
-      ...styles.botCheckboxRowStyle,
-    };
-  }
-  return attributes;
+			cursor: `url("${settings.general?.actionDisabledIcon}"), auto`,
+			...styles.botCheckboxRowStyle,
+		};
+	}
+	return attributes;
 };
 
 /**
@@ -424,23 +424,23 @@ const addStyleToCheckboxRows = (
  * @param settings options provided to the bot
  */
 const addStyleToCheckboxNextButton = (
-  classList: DOMTokenList,
-  attributes: { [key: string]: string | CSSProperties },
-  settings: Settings,
-  styles: Styles
+	classList: DOMTokenList,
+	attributes: { [key: string]: string | CSSProperties },
+	settings: Settings,
+	styles: Styles
 ) => {
-  if (classList.contains("rcb-checkbox-next-button")) {
-    attributes["style"] = {
-      ...(attributes["style"] as CSSProperties),
-      color:
+	if (classList.contains("rcb-checkbox-next-button")) {
+		attributes["style"] = {
+			...(attributes["style"] as CSSProperties),
+			color:
         styles.botCheckboxNextStyle?.color ?? settings.general?.primaryColor,
-      borderColor:
+			borderColor:
         styles.botCheckboxNextStyle?.color ?? settings.general?.primaryColor,
-      cursor: `url("${settings.general?.actionDisabledIcon}"), auto`,
-      ...styles.botCheckboxNextStyle,
-    };
-  }
-  return attributes;
+			cursor: `url("${settings.general?.actionDisabledIcon}"), auto`,
+			...styles.botCheckboxNextStyle,
+		};
+	}
+	return attributes;
 };
 
 /**
@@ -451,30 +451,30 @@ const addStyleToCheckboxNextButton = (
  * @param settings options provided to the bot
  */
 const addStyleToMediaDisplayContainer = (
-  classList: DOMTokenList,
-  attributes: { [key: string]: string | CSSProperties },
-  settings: Settings,
-  styles: Styles
+	classList: DOMTokenList,
+	attributes: { [key: string]: string | CSSProperties },
+	settings: Settings,
+	styles: Styles
 ) => {
-  if (
-    classList.contains("rcb-media-display-image-container") ||
+	if (
+		classList.contains("rcb-media-display-image-container") ||
     classList.contains("rcb-media-display-video-container")
-  ) {
-    attributes["style"] = {
-      ...(attributes["style"] as CSSProperties),
-      backgroundColor: settings.general?.primaryColor,
-      maxWidth: settings.userBubble?.showAvatar ? "65%" : "70%",
-      ...styles.mediaDisplayContainerStyle,
-    };
-  }
-  return attributes;
+	) {
+		attributes["style"] = {
+			...(attributes["style"] as CSSProperties),
+			backgroundColor: settings.general?.primaryColor,
+			maxWidth: settings.userBubble?.showAvatar ? "65%" : "70%",
+			...styles.mediaDisplayContainerStyle,
+		};
+	}
+	return attributes;
 };
 
 export {
-  saveChatHistory,
-  loadChatHistory,
-  getHistoryMessages,
-  setHistoryMessages,
-  clearHistoryMessages,
-  setHistoryStorageValues,
+	saveChatHistory,
+	loadChatHistory,
+	getHistoryMessages,
+	setHistoryMessages,
+	clearHistoryMessages,
+	setHistoryStorageValues,
 };


### PR DESCRIPTION
### Summary
This PR fixes an issue where removed messages could reappear ("ghost messages") after a page reload due to incremental chat history persistence logic not reflecting deletions. History is now rebuilt as a bounded snapshot on every update.

### Changes
- Refactored `saveChatHistory` to always rebuild a fresh snapshot (up to `maxEntries`).
- Removed legacy `historyLoaded` incremental logic.
- Ensures deletions and ordering are faithfully persisted.
- Added `ChatHistoryRemoval.test.ts` covering:
  - Persistence after removal.
  - Re-injecting same HTML content does not resurrect prior deleted entries.
- Added `v2.3.1 (UNRELEASED)` CHANGELOG entry.

### Rationale
Incremental offset-based persistence could not detect deletions, causing stale entries to remain in storage and rehydrate later. Full snapshot persistence is safer and still bounded by `maxEntries`.

### Testing
- Ran full test suite: all existing tests pass.
- New test validates removal persistence scenarios.
- Lint passes (with pre-commit hooks).

### No Breaking Changes
Behavior is improved; only internal persistence strategy changed.

