### PR TITLE
fix: use min-width/height instead of fixed dimensions for toggle button

### DIFF
--- a/src/components/ChatBotButton/ChatBotButton.css
+++ b/src/components/ChatBotButton/ChatBotButton.css
@@ -7,8 +7,8 @@
 	bottom: 20px;
 	right: 20px;
 	z-index: 9999;
-	width: 75px;
-	height: 75px;
+	min-width: 75px;
+	min-height: 75px;
 	border-radius: 50%;
 	border: none;
 	cursor: pointer;


### PR DESCRIPTION
Use min-width/min-height instead of fixed width/height so custom button styles can override the toggle button size.