### PR TITLE
fix: stoped voice recording and reset UI when chat window is closed

### DIFF
--- a/src/hooks/internal/useChatWindowInternal.ts
+++ b/src/hooks/internal/useChatWindowInternal.ts
@@ -5,6 +5,7 @@ import { useBotStatesContext } from "../../context/BotStatesContext";
 import { useBotRefsContext } from "../../context/BotRefsContext";
 import { useSettingsContext } from "../../context/SettingsContext";
 import { RcbEvent } from "../../constants/RcbEvent";
+import { stopVoiceRecording } from "../../services/VoiceService";
 
 /**
  * Internal custom hook for managing chat window logic.
@@ -25,6 +26,7 @@ export const useChatWindowInternal = () => {
 		setSyncedIsBotTyping,
 		setSyncedIsScrolling,
 		syncedIsBotTypingRef,
+		setSyncedVoiceToggledOn,
 		syncedIsChatWindowOpenRef,
 	} = useBotStatesContext();
 
@@ -77,6 +79,12 @@ export const useChatWindowInternal = () => {
 				return;
 			}
 		}
+		// stop voice recording when closing the chat window
+		if (syncedIsChatWindowOpenRef.current) {
+			stopVoiceRecording();
+			setSyncedVoiceToggledOn(false);
+		}
+
 		setSyncedIsChatWindowOpen(prev => {
 			// if currently false means opening so set unread count to 0
 			if (!prev) {


### PR DESCRIPTION
#### Description

When a user enables voice input and closes the chat window, the microphone continued recording in the background and the voice button UI remained in an active state with no indication to the user that audio was still being captured.

Closes #372 

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Added a call to `stopVoiceRecording()` and reset `voiceToggledOn` to false inside the `toggleChatWindow` function in `useChatWindowInternal.ts`. When the chat window is closed, the microphone recording turns off. The fix checks if the window is currently open before applying the cleanup so it only triggers on close, not on open.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)