### PR TITLE
fix: Fix attributes of html elements being lowercased when they are restored from history, breaking SVGs.

### DIFF
--- a/src/services/ChatHistoryService.tsx
+++ b/src/services/ChatHistoryService.tsx
@@ -232,8 +232,8 @@ const renderHTML = (html: string, settings: Settings, styles: Styles): ReactNode
 		} else {
 			const tagName = (node as Element).tagName.toLowerCase();
 			let attributes = Array.from((node as Element).attributes).reduce((acc, attr) => {
-				const attributeName = attr.name.toLowerCase();
-				if (attributeName === "style") {
+				const attributeNameLower = attr.name.toLowerCase();
+				if (attributeNameLower === "style") {
 					const styleProperties = attr.value.split(";").filter(property => property.trim() !== "");
 					const styleObject: { [key: string]: string } = {};
 					styleProperties.forEach(property => {
@@ -241,12 +241,12 @@ const renderHTML = (html: string, settings: Settings, styles: Styles): ReactNode
 						const reactCompliantKey = key.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
 						styleObject[reactCompliantKey] = value;
 					});
-					acc[attributeName] = styleObject;
+					acc[attributeNameLower] = styleObject;
 				} else if ((tagName === "audio" || tagName === "video")
-					&& attributeName === "controls" && attr.value === "") {
-					acc[attributeName] = "true";
+					&& attributeNameLower === "controls" && attr.value === "") {
+					acc[attributeNameLower] = "true";
 				} else {
-					acc[attributeName] = attr.value;
+					acc[attr.name] = attr.value;
 				}
 				return acc;
 			}, {} as { [key: string]: string | CSSProperties });


### PR DESCRIPTION
#### Description

Please include a brief summary of the change and include the relevant issue(s).

Fixes the `renderHTML` function to preserve the HTML attribute casing when restoring from history.

Closes #378

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)